### PR TITLE
chore: minor fixes, formatting, and CLI config support

### DIFF
--- a/numerical_illustration/numerical_illustration.py
+++ b/numerical_illustration/numerical_illustration.py
@@ -1,10 +1,28 @@
+"""Numerical illustration pipeline for CycGBM.
+
+Runs the full pipeline: data loading, preprocessing, tuning, fitting,
+prediction, evaluation, and saving results.
+
+Usage:
+    python numerical_illustration/numerical_illustration.py
+    python numerical_illustration/numerical_illustration.py --config path/to/config.yaml
+"""
+
+import argparse
 import logging
 
-from tasks import (evaluate_predictions, fit_models, load_input_data, predict,
-                   preprocess_input_data, save_results, setup_pipeline_run,
-                   tune_models)
+from tasks import (
+    evaluate_predictions,
+    fit_models,
+    load_input_data,
+    predict,
+    preprocess_input_data,
+    save_results,
+    setup_pipeline_run,
+    tune_models,
+)
 
-CONFIG_DIR = "numerical_illustration/config/demo_config.yaml"
+DEFAULT_CONFIG_DIR = "numerical_illustration/config/demo_config.yaml"
 
 # Set up a logger
 logging.basicConfig(level=logging.INFO)
@@ -12,8 +30,17 @@ logger = logging.getLogger(__name__)
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Run the numerical illustration pipeline.")
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG_DIR,
+        help="Path to config YAML (default: %(default)s)",
+    )
+    args = parser.parse_args()
+    logger.info(f"Using config: {args.config}")
+
     # Setup the numerical illustration
-    config, rng, output_path = setup_pipeline_run(config_path=CONFIG_DIR)
+    config, rng, output_path = setup_pipeline_run(config_path=args.config)
     logger.info("Setup complete")
 
     # Load data
@@ -62,7 +89,7 @@ def main():
     )
     logger.info("Results saved")
 
-    logger.info((metrics.astype(float) / 1e2).round(2))
+    logger.info(metrics.astype(float).round(4))
 
 
 if __name__ == "__main__":

--- a/numerical_illustration/tasks/baseline_models/cyc_glm.py
+++ b/numerical_illustration/tasks/baseline_models/cyc_glm.py
@@ -29,7 +29,8 @@ class CyclicGeneralizedLinearModel:
         """
         Fit the model.
         """
-        z = np.zeros((self.d, len(y)))
+        n = len(y)
+        z = np.zeros((self.d, n))
         self.z0 = minimize(
             fun=lambda z0: self.distribution.loss(y=y, z=z0[:, None] + z, w=w).sum(),
             x0=self.distribution.mme(y=y, w=w),
@@ -42,8 +43,8 @@ class CyclicGeneralizedLinearModel:
         for i in range(self.max_iter):
             for j in range(self.d):
                 g = self.distribution.grad(y=y, z=z, w=w, j=j)
-                # Update patameter estimate
-                beta[i, j] = beta[i - 1, j] - self.eps * g @ X
+                # Update parameter estimate; divide by n so step size is data-size invariant
+                beta[i, j] = beta[i - 1, j] - (self.eps / n) * g @ X
                 # Update parameter estimate
                 z[j] = self.z0[j] + beta[i, j] @ X.T
 
@@ -54,7 +55,7 @@ class CyclicGeneralizedLinearModel:
             if i == self.max_iter - 1:
                 Warning("CGLM model did not converge")
 
-        self.beta = beta[-1]
+        self.beta = beta[i]
 
     def predict(self, X: np.ndarray) -> np.ndarray:
         """

--- a/numerical_illustration/tasks/evaluate_predictions.py
+++ b/numerical_illustration/tasks/evaluate_predictions.py
@@ -43,6 +43,6 @@ def evaluate_predictions(
             y = data_set["y"].values
             w = data_set["w"].values
             z = data_set[theta_cols].values.T
-            metrics.at[model_name, data_name] = distribution.loss(y=y, z=z, w=w).sum()
+            metrics.at[model_name, data_name] = distribution.loss(y=y, z=z, w=w).mean()
 
     return metrics

--- a/numerical_illustration/tasks/save_results.py
+++ b/numerical_illustration/tasks/save_results.py
@@ -19,12 +19,8 @@ def save_results(
     test_data.to_csv(os.path.join(output_path, "test_data.csv"), index=False)
     _save_tuning_results(loss_results, output_path)
     metrics.to_csv(os.path.join(output_path, "metrics.csv"), index=True)
-    _save_feature_importances(models ={
-        CGBM: models[CGBM],
-        GBM: models[GBM],
-    },
-    output_path = output_path
-    )
+    gbm_models = {k: models[k] for k in [CGBM, GBM] if k in models}
+    _save_feature_importances(models=gbm_models, output_path=output_path)
 
 def _save_tuning_results(
     loss_results: Dict[str, Dict[str, List[float]]], output_path: str
@@ -33,11 +29,12 @@ def _save_tuning_results(
         return
     loss_folder = os.path.join(output_path, "loss")
     os.makedirs(loss_folder, exist_ok=True)
-    for dataset in ["train", "validation"]:
+    for dataset in ["train", "valid"]:
         dataset_folder = os.path.join(loss_folder, dataset)
+        os.makedirs(dataset_folder, exist_ok=True)
         for model_name, losses in loss_results.items():
             df_loss = pd.DataFrame()
-            avg_loss = np.mean(losses["train"], axis=0)
+            avg_loss = np.mean(losses[dataset], axis=0)
             # Save the loss after both parameter updates as 0 and 1 respectively
             df_loss[f"{dataset}_0"] = avg_loss[:, 0]
             df_loss[f"{dataset}_1"] = avg_loss[:, 1]

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -54,7 +54,6 @@ def tune_models(
             n_estimators[model_name] = tuning_results["n_estimators"]
 
     else:
-        n_estimators = {}
         n_estimators[CGBM] = config[MODEL_HYPERPARAMS][CGBM][N_ESTIMATORS]
-        n_estimators[GBM] = [config[MODEL_HYPERPARAMS][GBM][N_ESTIMATORS]] + [0]*(len(n_estimators[CGBM])-1)
+        n_estimators[GBM] = [config[MODEL_HYPERPARAMS][GBM][N_ESTIMATORS]] + [0] * (len(n_estimators[CGBM]) - 1)
     return loss_results, n_estimators


### PR DESCRIPTION
## Summary

Minor bug fixes, formatting improvements, and a CLI config argument.

### Changes
- **cyc_gbm.py**: Ruff formatting (line wrapping, assignment alignment), remove stale comment
- **cyc_glm.py**: Fix typo, divide step by n for data-size invariance, use beta[i] instead of beta[-1] after convergence
- **evaluate_predictions.py**: Use .mean() instead of .sum() for loss metrics
- **numerical_illustration.py**: Add argparse CLI for config path (--config), log which config is used, fix import formatting, use .round(4)
- **save_results.py**: Fix _save_tuning_results - rename validation to valid, add makedirs for dataset folder, fix avg_loss to use correct dataset key, make feature importances conditional on which models exist
- **tune_models.py**: Remove redundant n_estimators = {}, add spacing