### PR TITLE
[Fix] Add __main__.py for numerical_illustration package

### DIFF
--- a/numerical_illustration/__main__.py
+++ b/numerical_illustration/__main__.py
@@ -1,0 +1,10 @@
+"""Allow running the numerical illustration as a package.
+
+Usage:
+    python -m numerical_illustration
+    python numerical_illustration
+"""
+
+from numerical_illustration.numerical_illustration import main
+
+main()

--- a/numerical_illustration/numerical_illustration.py
+++ b/numerical_illustration/numerical_illustration.py
@@ -4,14 +4,15 @@ Runs the full pipeline: data loading, preprocessing, tuning, fitting,
 prediction, evaluation, and saving results.
 
 Usage:
-    python numerical_illustration/numerical_illustration.py
+    python numerical_illustration
+    python -m numerical_illustration
     python numerical_illustration/numerical_illustration.py --config path/to/config.yaml
 """
 
 import argparse
 import logging
 
-from tasks import (
+from .tasks import (
     evaluate_predictions,
     fit_models,
     load_input_data,


### PR DESCRIPTION
## Summary

`python numerical_illustration` failed with `can't find '__main__' module` because the package lacked a `__main__.py` entry point. The existing `numerical_illustration.py` also used bare `from tasks import ...` which only resolves when the script is run directly from inside the package directory.

## Changes

- **Add `numerical_illustration/__main__.py`** — delegates to `main()` so `python numerical_illustration` and `python -m numerical_illustration` both work.
- **Fix imports in `numerical_illustration.py`** — change `from tasks import ...` to `from .tasks import ...` (relative import) for correct resolution when invoked as a package.
