### PR TITLE
[Fix] Resolve ImportError in numerical_illustration __main__

### DIFF
--- a/numerical_illustration/__main__.py
+++ b/numerical_illustration/__main__.py
@@ -5,6 +5,11 @@ Usage:
     python numerical_illustration
 """
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from numerical_illustration.numerical_illustration import main
 
 main()


### PR DESCRIPTION
## Problem

`python numerical_illustration` fails with `ImportError: attempted relative import with no known parent package` because `runpy` adds `numerical_illustration/` (not the repo root) to `sys.path`, so the package-qualified import in `__main__.py` and the relative import in `numerical_illustration.py` both fail.

## Fix

Insert the repo root into `sys.path` at the top of `__main__.py` before any imports. This ensures both `python numerical_illustration` and `python -m numerical_illustration` resolve imports correctly.
