### PR TITLE
[Feature] Add mean rank across bootstrap iterations

### DIFF
--- a/numerical_illustration/numerical_illustration.py
+++ b/numerical_illustration/numerical_illustration.py
@@ -107,6 +107,16 @@ def main():
         np.std(stacked, axis=0), index=ref.index, columns=ref.columns
     )
 
+    # Compute mean rank across bootstrap iterations (excluding "true")
+    model_names = [idx for idx in ref.index if idx != "true"]
+    mean_rank = pd.DataFrame(
+        np.stack(
+            [m.loc[model_names].rank().values for m in all_metrics], axis=0
+        ).mean(axis=0),
+        index=model_names,
+        columns=ref.columns,
+    )
+
     # Save results (last iteration's data + aggregated metrics)
     save_results(
         train_data=train_data,
@@ -114,6 +124,7 @@ def main():
         loss_results=tuning_results,
         metrics_mean=metrics_mean,
         metrics_std=metrics_std,
+        mean_rank=mean_rank,
         models=models,
         output_path=output_path,
     )
@@ -121,6 +132,7 @@ def main():
 
     formatted = _format_metrics(metrics_mean, metrics_std)
     logger.info(f"\n{formatted}")
+    logger.info(f"Mean rank (models only):\n{mean_rank}")
 
 
 if __name__ == "__main__":

--- a/numerical_illustration/tasks/save_results.py
+++ b/numerical_illustration/tasks/save_results.py
@@ -13,13 +13,14 @@ def save_results(
     loss_results: Dict[str, Dict[str, List[float]]],
     metrics_mean: pd.DataFrame,
     metrics_std: pd.DataFrame,
+    mean_rank: pd.DataFrame,
     models: Dict[str, CyclicalGradientBooster],
     output_path: str,
 ) -> None:
     train_data.to_csv(os.path.join(output_path, "train_data.csv"), index=False)
     test_data.to_csv(os.path.join(output_path, "test_data.csv"), index=False)
     _save_tuning_results(loss_results, output_path)
-    _save_metrics(metrics_mean, metrics_std, output_path)
+    _save_metrics(metrics_mean, metrics_std, mean_rank, output_path)
     gbm_models = {k: models[k] for k in [CGBM, GBM] if k in models}
     _save_feature_importances(models=gbm_models, output_path=output_path)
 
@@ -27,6 +28,7 @@ def save_results(
 def _save_metrics(
     metrics_mean: pd.DataFrame,
     metrics_std: pd.DataFrame,
+    mean_rank: pd.DataFrame,
     output_path: str,
 ) -> None:
     """Save aggregated metrics with separate mean and std columns."""
@@ -34,6 +36,8 @@ def _save_metrics(
     for col in metrics_mean.columns:
         combined[f"{col}_mean"] = metrics_mean[col]
         combined[f"{col}_std"] = metrics_std[col]
+    for col in mean_rank.columns:
+        combined[f"{col}_mean_rank"] = mean_rank[col]
     combined.to_csv(os.path.join(output_path, "metrics.csv"), index=True)
 
 def _save_tuning_results(


### PR DESCRIPTION
## Summary

Add mean rank tracking across bootstrap iterations in the numerical illustration. For each bootstrap, models (excluding "true") are ranked by loss (rank 1 = lowest = best). The mean rank across all bootstraps is computed and saved, giving a single summary number per model.

## Changes

- **`numerical_illustration.py`**: Compute `mean_rank` DataFrame after aggregating metrics; pass to `save_results`; log the result.
- **`save_results.py`**: Accept `mean_rank` parameter; write `train_mean_rank` and `test_mean_rank` columns to `metrics.csv`.
