### PR TITLE
[codex] Replace typing imports with native Python type hints

### DIFF
--- a/cyc_gbm/cyc_gbm.py
+++ b/cyc_gbm/cyc_gbm.py
@@ -1,4 +1,3 @@
-from typing import List, Union, Optional
 import logging
 
 import numpy as np
@@ -24,13 +23,13 @@ class CyclicalGradientBooster:
 
     def __init__(
         self,
-        distribution: Union[str, Distribution] = "normal",
-        learning_rate: Union[float, List[float]] = 0.1,
-        n_estimators: Union[int, List[int]] = 100,
-        min_samples_split: Union[int, List[int]] = 2,
-        min_samples_leaf: Union[int, List[int]] = 1,
-        max_depth: Union[int, List[int]] = 3,
-        feature_selection: Optional[List[List[Union[str, int]]]] = None,
+        distribution: str | Distribution = "normal",
+        learning_rate: float | list[float] = 0.1,
+        n_estimators: int | list[int] = 100,
+        min_samples_split: int | list[int] = 2,
+        min_samples_leaf: int | list[int] = 1,
+        max_depth: int | list[int] = 3,
+        feature_selection: list[list[str | int]] | None = None,
     ):
         """
         Initialize a CyclicalGradientBooster object.
@@ -61,7 +60,7 @@ class CyclicalGradientBooster:
         self.feature_names = None
         self.n_features = None
 
-    def _setup_hyper_parameter(self, hyper_parameter) -> List:
+    def _setup_hyper_parameter(self, hyper_parameter) -> list:
         """
         Initialize parameter to default_value if parameter is not a list or numpy array.
 
@@ -97,9 +96,9 @@ class CyclicalGradientBooster:
 
     def fit(
         self,
-        X: Union[np.ndarray, pd.DataFrame],
-        y: Union[np.ndarray, pd.Series, pd.DataFrame],
-        w: Union[np.ndarray, pd.Series, float] = None,
+        X: np.ndarray | pd.DataFrame,
+        y: np.ndarray | pd.Series | pd.DataFrame,
+        w: np.ndarray | pd.Series | float = None,
         verbose: bool = True,
     ) -> None:
         """
@@ -148,7 +147,7 @@ class CyclicalGradientBooster:
             logger.info(f"Progress: {int(new_progress * 100)}%")
         return last_progress
 
-    def _initialize_feature_metadata(self, X: Union[np.ndarray, pd.DataFrame]) -> None:
+    def _initialize_feature_metadata(self, X: np.ndarray | pd.DataFrame) -> None:
         """Get the feature names from the input data.
         If the input data is a DataFrame, the column names are returned.
         Otherwise, the features are named 0, 1, ..., p-1.
@@ -173,7 +172,7 @@ class CyclicalGradientBooster:
         self,
         y: np.ndarray,
         w: np.ndarray,
-        z: Optional[np.ndarray] = None,
+        z: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Initialize the estimate of the parameter vector z0.
@@ -192,11 +191,11 @@ class CyclicalGradientBooster:
 
     def add_tree(
         self,
-        X: Union[np.ndarray, pd.DataFrame],
-        y: Union[np.ndarray, pd.Series, pd.DataFrame],
+        X: np.ndarray | pd.DataFrame,
+        y: np.ndarray | pd.Series | pd.DataFrame,
         j: int,
-        z: Optional[Union[np.ndarray, pd.DataFrame]] = None,
-        w: Union[np.ndarray, pd.Series, float] = 1,
+        z: np.ndarray | pd.DataFrame | None = None,
+        w: np.ndarray | pd.Series | float = 1,
     ) -> None:
         """
         Updates the current boosting model with one additional tree at dimension j.
@@ -224,8 +223,8 @@ class CyclicalGradientBooster:
         self.n_estimators[j] += 1
 
     def predict(
-        self, X: Union[np.ndarray, pd.DataFrame]
-    ) -> Union[np.ndarray, pd.DataFrame]:
+        self, X: np.ndarray | pd.DataFrame
+    ) -> np.ndarray | pd.DataFrame:
         """
         Predict response values for the input data using the trained model.
 
@@ -250,8 +249,8 @@ class CyclicalGradientBooster:
         )
 
     def compute_feature_importances(
-        self, j: Union[str, int] = "all", normalize: bool = True
-    ) -> Union[np.ndarray, pd.Series]:
+        self, j: str | int = "all", normalize: bool = True
+    ) -> np.ndarray | pd.Series:
         """
         Computes the feature importances for parameter dimension j
 
@@ -284,7 +283,7 @@ class CyclicalGradientBooster:
             for i in range(self.n_features)
         }
 
-    def reset(self, n_estimators: Optional[Union[int, List[int]]] = None) -> None:
+    def reset(self, n_estimators: int | list[int] | None = None) -> None:
         """
         Resets the model to its initial state.
 

--- a/cyc_gbm/utils/distributions.py
+++ b/cyc_gbm/utils/distributions.py
@@ -1,4 +1,4 @@
-from typing import Callable, Type, Union, Optional
+from typing import Callable
 
 import numpy as np
 from scipy.optimize import minimize
@@ -23,7 +23,7 @@ def sigm_inv(x: np.ndarray) -> np.ndarray:
     return np.log(x / (1 - x))
 
 
-def inherit_docstrings(cls: Type) -> Type:
+def inherit_docstrings(cls: type) -> type:
     """
     Decorator to copy docstrings from base class to derived class methods.
 
@@ -43,13 +43,13 @@ def inherit_docstrings(cls: Type) -> Type:
 class Distribution:
     def __init__(
         self,
-        n_dim: Optional[int] = None,
+        n_dim: int | None = None,
     ):
         """Initialize a distribution object."""
         self.n_dim = n_dim
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         """
         Calculates the loss of the parameter estimates and the response.
@@ -62,7 +62,7 @@ class Distribution:
         pass
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         """
         Calculates the gradients of the loss function with respect to the parameters.
@@ -88,9 +88,9 @@ class Distribution:
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """Simulate values given parameter values in z
 
@@ -129,7 +129,7 @@ class MultivariateNormalDistribution(Distribution):
         super().__init__(n_dim=3)
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -148,7 +148,7 @@ class MultivariateNormalDistribution(Distribution):
         return z[1] + 0.5 * mu_term * rho_term / s2
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -191,7 +191,7 @@ class MultivariateNormalDistribution(Distribution):
                 )
             )
 
-    def mme(self, y: np.ndarray, w: Union[np.ndarray, float] = 1.0) -> np.ndarray:
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
         # Return the mean, variance and correlation of a 2d normal distribution
         if np.any(w != 1):
             raise NotImplementedError(
@@ -205,9 +205,9 @@ class MultivariateNormalDistribution(Distribution):
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -228,7 +228,7 @@ class MultivariateNormalDistribution(Distribution):
         )
 
     def moment(
-        self, z: np.ndarray, k: int, w: Union[np.ndarray, float] = 1.0
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -254,7 +254,7 @@ class NormalDistribution(Distribution):
         super().__init__(n_dim=2)
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         return (
             0.5 * np.log(w)
@@ -263,14 +263,14 @@ class NormalDistribution(Distribution):
         )
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if j == 0:
             return -np.exp(-2 * z[1]) * (y - w * z[0])
         elif j == 1:
             return 1 - np.exp(-2 * z[1]) * (y - w * z[0]) ** 2 / w
 
-    def mme(self, y: np.ndarray, w: Union[np.ndarray, float] = 1.0) -> np.ndarray:
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
         if not isinstance(w, np.ndarray):
             w = np.array([w] * len(y))
         mean = y.sum() / w.sum()
@@ -280,16 +280,16 @@ class NormalDistribution(Distribution):
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         if rng is None:
             rng = np.random.default_rng(seed=random_state)
         return rng.normal(w * z[0], w**0.5 * np.exp(z[1]))
 
     def moment(
-        self, z: np.ndarray, k: int, w: Union[np.ndarray, float] = 1.0
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if k == 1:
             return w * z[0]
@@ -309,7 +309,7 @@ class NegativeBinomialDistribution(Distribution):
         super().__init__(n_dim=2)
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         return (
             loggamma(w * np.exp(z[1]))
@@ -320,7 +320,7 @@ class NegativeBinomialDistribution(Distribution):
         )
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if j == 0:
             return (w * np.exp(z[1]) + y) * np.exp(z[0]) / (
@@ -340,7 +340,7 @@ class NegativeBinomialDistribution(Distribution):
                 )
             )
 
-    def mme(self, y: np.ndarray, w: Union[np.ndarray, float] = 1.0) -> np.ndarray:
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
         if isinstance(w, float):
             w = np.array([w] * len(y))
         mean = y.sum() / w.sum()
@@ -351,9 +351,9 @@ class NegativeBinomialDistribution(Distribution):
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         if rng is None:
             rng = np.random.default_rng(seed=random_state)
@@ -363,7 +363,7 @@ class NegativeBinomialDistribution(Distribution):
         return y.astype(float)
 
     def moment(
-        self, z: np.ndarray, k: int, w: Union[np.ndarray, float] = 1.0
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if k == 1:
             return w * np.exp(z[0])
@@ -383,7 +383,7 @@ class InverseGaussianDistribution(Distribution):
         super().__init__(n_dim=2)
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -395,7 +395,7 @@ class InverseGaussianDistribution(Distribution):
         )
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -409,7 +409,7 @@ class InverseGaussianDistribution(Distribution):
                 - 1
             )
 
-    def mme(self, y: np.ndarray, w: Union[np.ndarray, float] = 1.0) -> np.ndarray:
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
                 "Weighted loss not implemented for InverseGaussianDistribution"
@@ -423,9 +423,9 @@ class InverseGaussianDistribution(Distribution):
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -436,7 +436,7 @@ class InverseGaussianDistribution(Distribution):
         return rng.wald(np.exp(z[0]), np.exp(z[1]))
 
     def moment(
-        self, z: np.ndarray, k: int, w: Union[np.ndarray, float] = 1.0
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -461,7 +461,7 @@ class GammaDistribution(Distribution):
         super().__init__(n_dim=2)
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         return (
             loggamma(w * np.exp(-z[1]))
@@ -470,7 +470,7 @@ class GammaDistribution(Distribution):
         )
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if j == 0:
             return np.exp(-z[1]) * (w - y * np.exp(-z[0]))
@@ -488,7 +488,7 @@ class GammaDistribution(Distribution):
                 )
             )
 
-    def mme(self, y: np.ndarray, w: Union[np.ndarray, float] = 1.0) -> np.ndarray:
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
         if isinstance(w, float):
             w = np.array([w] * len(y))
         mean = y.sum() / w.sum()
@@ -501,9 +501,9 @@ class GammaDistribution(Distribution):
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         if rng is None:
             rng = np.random.default_rng(seed=random_state)
@@ -512,7 +512,7 @@ class GammaDistribution(Distribution):
         return rng.gamma(shape=shape, scale=scale)
 
     def moment(
-        self, z: np.ndarray, k: int, w: Union[np.ndarray, float] = 1.0
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if k == 1:
             return w * np.exp(z[0])
@@ -533,7 +533,7 @@ class BetaPrimeDistribution(Distribution):
         super().__init__(n_dim=2)
 
     def loss(
-        self, y: np.ndarray, z: np.ndarray, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(np.any(w != 1)):
             raise NotImplementedError(
@@ -548,7 +548,7 @@ class BetaPrimeDistribution(Distribution):
         )
 
     def grad(
-        self, y: np.ndarray, z: np.ndarray, j: int, w: Union[np.ndarray, float] = 1.0
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -580,7 +580,7 @@ class BetaPrimeDistribution(Distribution):
                 )
             )
 
-    def mme(self, y: np.ndarray, w: Union[np.ndarray, float] = 1.0) -> np.ndarray:
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
                 "Weighted loss not implemented for BetaPrimeDistribution"
@@ -595,9 +595,9 @@ class BetaPrimeDistribution(Distribution):
     def simulate(
         self,
         z: np.ndarray,
-        w: Union[np.ndarray, float] = 1.0,
-        random_state: Union[int, None] = None,
-        rng: Union[np.random.Generator, None] = None,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -613,7 +613,7 @@ class BetaPrimeDistribution(Distribution):
         return y0 / (1 - y0)
 
     def moment(
-        self, z: np.ndarray, k: int, w: Union[np.ndarray, float] = 1.0
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
     ) -> np.ndarray:
         if np.any(w != 1):
             raise NotImplementedError(
@@ -629,21 +629,21 @@ class BetaPrimeDistribution(Distribution):
 class CustomDistribution(Distribution):
     def __init__(
         self,
-        loss: Callable[[np.ndarray, np.ndarray, Union[np.ndarray, float]], np.ndarray],
+        loss: Callable[[np.ndarray, np.ndarray, np.ndarray | float], np.ndarray],
         grad: Callable[
-            [np.ndarray, np.ndarray, int, Union[np.ndarray, float]], np.ndarray
+            [np.ndarray, np.ndarray, int, np.ndarray | float], np.ndarray
         ],
-        mme: Callable[[np.ndarray, Union[np.ndarray, float]], np.ndarray],
+        mme: Callable[[np.ndarray, np.ndarray | float], np.ndarray],
         simulate: Callable[
             [
                 np.ndarray,
-                Union[np.ndarray, float],
-                Union[int, None],
-                Union[np.random.Generator, None],
+                np.ndarray | float,
+                int | None,
+                np.random.Generator | None,
             ],
             np.ndarray,
         ],
-        moment: Callable[[np.ndarray, int, Union[np.ndarray, float]], np.ndarray],
+        moment: Callable[[np.ndarray, int, np.ndarray | float], np.ndarray],
         d: int,
     ):
         """
@@ -666,31 +666,19 @@ class CustomDistribution(Distribution):
 
 def initiate_distribution(
     distribution: str = "custom",
-    loss: Union[
-        None, Callable[[np.ndarray, np.ndarray, Union[np.ndarray, float]], np.ndarray]
-    ] = None,
-    grad: Union[
-        None,
-        Callable[[np.ndarray, np.ndarray, int, Union[np.ndarray, float]], np.ndarray],
-    ] = None,
-    mme: Union[
-        None, Callable[[np.ndarray, Union[np.ndarray, float]], np.ndarray]
-    ] = None,
-    simulate: Union[
-        None,
-        Callable[
-            [
-                np.ndarray,
-                Union[np.ndarray, float],
-                Union[int, None],
-                Union[np.random.Generator, None],
-            ],
+    loss: Callable[[np.ndarray, np.ndarray, np.ndarray | float], np.ndarray] | None = None,
+    grad: Callable[[np.ndarray, np.ndarray, int, np.ndarray | float], np.ndarray] | None = None,
+    mme: Callable[[np.ndarray, np.ndarray | float], np.ndarray] | None = None,
+    simulate: Callable[
+        [
             np.ndarray,
+            np.ndarray | float,
+            int | None,
+            np.random.Generator | None,
         ],
-    ] = None,
-    moment: Union[
-        None, Callable[[np.ndarray, int, Union[np.ndarray, float]], np.ndarray]
-    ] = None,
+        np.ndarray,
+    ] | None = None,
+    moment: Callable[[np.ndarray, int, np.ndarray | float], np.ndarray] | None = None,
     n_dim: int = 2,
 ) -> Distribution:
     """

--- a/cyc_gbm/utils/fix_datatype.py
+++ b/cyc_gbm/utils/fix_datatype.py
@@ -1,15 +1,13 @@
-from typing import Tuple, Union, Optional, List
-
 import numpy as np
 import pandas as pd
 
 
 def fix_datatype(
-    X: Union[np.ndarray, pd.DataFrame],
-    y: Optional[Union[np.ndarray, pd.Series, pd.DataFrame]] = None,
-    w: Optional[Union[np.ndarray, pd.Series, pd.DataFrame, float]] = None,
-    feature_names: Optional[List[str]] = None,
-) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray, np.ndarray]]:
+    X: np.ndarray | pd.DataFrame,
+    y: np.ndarray | pd.Series | pd.DataFrame | None = None,
+    w: np.ndarray | pd.Series | pd.DataFrame | float | None = None,
+    feature_names: list[str] | None = None,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Convert data to numpy arrays if they are pandas dataframes or series.
 

--- a/cyc_gbm/utils/tuning.py
+++ b/cyc_gbm/utils/tuning.py
@@ -1,4 +1,3 @@
-from typing import Union, List, Dict, Tuple, Optional
 import logging
 
 import numpy as np
@@ -12,14 +11,14 @@ logger = logging.getLogger(__name__)
 def tune_n_estimators(
     X: np.ndarray,
     y: np.ndarray,
-    w: Union[np.ndarray, float] = 1.0,
+    w: np.ndarray | float = 1.0,
     model: CyclicalGradientBooster = CyclicalGradientBooster(),
-    n_estimators_max: Union[int, List[int]] = 1000,
+    n_estimators_max: int | list[int] = 1000,
     n_splits: int = 4,
-    rng: Optional[np.random.Generator] = None,
-    random_state: Optional[int] = None,
+    rng: np.random.Generator | None = None,
+    random_state: int | None = None,
     log_prefix: str = "",
-) -> Dict[str, Union[List[int], np.ndarray]]:
+) -> dict[str, list[int] | np.ndarray]:
     """Finds a suitable n_estimators hyperparameter of a CycGBM model using k-fold cross-validation.
 
     :param X: The input data matrix of shape (n_samples, n_features).
@@ -79,11 +78,11 @@ def tune_n_estimators(
 def _fold_split(
     X: np.ndarray,
     y: np.ndarray,
-    w: Union[float, np.ndarray],
+    w: float | np.ndarray,
     n_splits: int,
     rng: np.random.Generator,
-) -> Dict[
-    int, Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+) -> dict[
+    int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
 ]:
     """Split data into k folds.
 
@@ -113,9 +112,9 @@ def _fold_split(
 
 
 def _evaluate_fold(
-    fold: Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    fold: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
     model: CyclicalGradientBooster,
-    n_estimators_max: List[int],
+    n_estimators_max: list[int],
     log_prefix: str = "",
 ):
     X_train, y_train, w_train, X_valid, y_valid, w_valid = fold
@@ -200,9 +199,9 @@ def _has_tuning_converged(
 
 def _find_n_estimators(
     loss: np.ndarray,
-    n_estimators_max: List[int],
+    n_estimators_max: list[int],
     log_prefix: str = "",
-) -> List[int]:
+) -> list[int]:
     loss_delta = np.zeros_like(loss)
     loss_delta[1:, 0] = loss[1:, 0] - loss[:-1, -1]
     loss_delta[1:, 1:] = loss[1:, 1:] - loss[1:, :-1]

--- a/numerical_illustration/schema/config.py
+++ b/numerical_illustration/schema/config.py
@@ -1,6 +1,6 @@
 """Root configuration model that composes all sub-configs."""
 
-from typing import Annotated, Dict, List, Self, Union
+from typing import Annotated, Self
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -24,7 +24,7 @@ class NumericalIllustrationConfig(BaseModel):
     """
 
     data: Annotated[
-        Union[SimulationConfig, LocalDataConfig],
+        SimulationConfig | LocalDataConfig,
         Field(discriminator="data_source"),
     ]
     output: DumpingConfig = Field(default_factory=DumpingConfig)
@@ -33,21 +33,18 @@ class NumericalIllustrationConfig(BaseModel):
     tuning: TuningConfig = Field(default_factory=TuningConfig)
 
     @property
-    def model_names(self) -> List[str]:
+    def model_names(self) -> list[str]:
         """List of model class name strings."""
         return [m.model_class for m in self.models]
 
     @property
-    def model_configs_by_class(self) -> Dict[ModelClass, ModelConfig]:
+    def model_configs_by_class(self) -> dict[ModelClass, ModelConfig]:
         """Lookup of model configs keyed by their ModelClass."""
         return {m.model_class: m for m in self.models}
 
     @model_validator(mode="after")
     def no_bootstrap_with_local_data(self) -> Self:
-        if (
-            self.bootstrap.n_bootstraps > 1
-            and isinstance(self.data, LocalDataConfig)
-        ):
+        if self.bootstrap.n_bootstraps > 1 and isinstance(self.data, LocalDataConfig):
             raise ValueError(
                 "Bootstrap (n_bootstraps > 1) is not supported with local file "
                 "data source. Use simulation or set n_bootstraps to 1."

--- a/numerical_illustration/schema/models.py
+++ b/numerical_illustration/schema/models.py
@@ -1,6 +1,6 @@
 """Model configuration models (one per model type)."""
 
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
@@ -50,7 +50,7 @@ class CyclicalGradientBoostingMachineConfig(BaseModel):
     model_class: Literal[ModelClass.CGBM]
     n_estimators: list[int] = Field(default_factory=lambda: [600, 600])
     max_depth: int = 3
-    learning_rate: Union[float, list[float]] = 0.05
+    learning_rate: float | list[float] = 0.05
 
 
 class NaturalGradientBoostingMachineConfig(BaseModel):
@@ -100,12 +100,10 @@ class InterceptConfig(BaseModel):
 
 
 ModelConfig = Annotated[
-    Union[
-        GradientBoostingMachineConfig,
-        CyclicalGradientBoostingMachineConfig,
-        NaturalGradientBoostingMachineConfig,
-        CyclicalGeneralizedLinearModelConfig,
-        InterceptConfig,
-    ],
+    GradientBoostingMachineConfig
+    | CyclicalGradientBoostingMachineConfig
+    | NaturalGradientBoostingMachineConfig
+    | CyclicalGeneralizedLinearModelConfig
+    | InterceptConfig,
     Field(discriminator="model_class"),
 ]

--- a/numerical_illustration/tasks/baseline_models/cyc_glm.py
+++ b/numerical_illustration/tasks/baseline_models/cyc_glm.py
@@ -1,5 +1,3 @@
-from typing import List, Union
-
 import numpy as np
 from scipy.optimize import minimize
 
@@ -15,7 +13,7 @@ class CyclicGeneralizedLinearModel:
         distribution: Distribution,
         max_iter: int = 1000,
         tol: float = 1e-5,
-        eps: Union[List[float], float] = 1e-7,
+        eps: list[float] | float = 1e-7,
     ):
         """
         Initialize the model.

--- a/numerical_illustration/tasks/baseline_models/intercept_model.py
+++ b/numerical_illustration/tasks/baseline_models/intercept_model.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import numpy as np
 from scipy.optimize import minimize
 
@@ -26,7 +24,7 @@ class InterceptModel:
         self,
         X: np.ndarray,
         y: np.ndarray,
-        w: Union[np.ndarray, float] = 1,
+        w: np.ndarray | float = 1,
     ) -> None:
         """
         Fit the model.

--- a/numerical_illustration/tasks/baseline_models/ngboost_model.py
+++ b/numerical_illustration/tasks/baseline_models/ngboost_model.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 import numpy as np
 from ngboost import NGBRegressor
@@ -55,7 +54,7 @@ class NGBoostModel:
         self,
         X: np.ndarray,
         y: np.ndarray,
-        w: Union[np.ndarray, float] = 1,
+        w: np.ndarray | float = 1,
     ) -> None:
         self._model = NGBRegressor(
             Dist=Normal,

--- a/numerical_illustration/tasks/evaluate_predictions.py
+++ b/numerical_illustration/tasks/evaluate_predictions.py
@@ -1,5 +1,4 @@
 from collections import deque
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -11,7 +10,7 @@ def evaluate_predictions(
     train_data: pd.DataFrame,
     test_data: pd.DataFrame,
     distribution: Distribution,
-    model_names: List[str],
+    model_names: list[str],
     is_simulation: bool,
 ) -> pd.DataFrame:
     """Evaluate the predictions.

--- a/numerical_illustration/tasks/fit_models.py
+++ b/numerical_illustration/tasks/fit_models.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Iterable
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -28,9 +28,9 @@ def fit_models(
     distribution: Distribution,
     train_data: pd.DataFrame,
     rng: np.random.Generator,
-    n_estimators: Dict[str, List[int]],
+    n_estimators: dict[str, list[int]],
     log_prefix: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fit the models specified in the config.
 
     Args:
@@ -60,7 +60,7 @@ def fit_models(
 def _build_and_fit(
     model_config: ModelConfig,
     distribution: Distribution,
-    n_estimators: Dict[str, List[int]],
+    n_estimators: dict[str, list[int]],
     X: np.ndarray,
     y: np.ndarray,
     w: np.ndarray,

--- a/numerical_illustration/tasks/predict.py
+++ b/numerical_illustration/tasks/predict.py
@@ -1,5 +1,3 @@
-from typing import Dict, Union
-
 import numpy as np
 import pandas as pd
 
@@ -10,9 +8,9 @@ from .utils.utils import get_targets_features
 
 
 def predict(
-    models: Dict[
+    models: dict[
         str,
-        Union[InterceptModel, CyclicGeneralizedLinearModel, CyclicalGradientBooster],
+        InterceptModel | CyclicGeneralizedLinearModel | CyclicalGradientBooster,
     ],
     data: pd.DataFrame,
 ) -> pd.DataFrame:

--- a/numerical_illustration/tasks/preprocess_input_data.py
+++ b/numerical_illustration/tasks/preprocess_input_data.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import numpy as np
 import pandas as pd
 
@@ -10,7 +8,7 @@ def preprocess_input_data(
     data_config: DataConfig,
     data: pd.DataFrame,
     rng: np.random.Generator,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Preprocess the input data.
 
     Args:
@@ -35,8 +33,8 @@ def preprocess_input_data(
 def _normalize_features(
     train_data: pd.DataFrame,
     test_data: pd.DataFrame,
-    features: List[str],
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    features: list[str],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Normalize features using training-set statistics only.
 
     Args:
@@ -53,7 +51,7 @@ def _normalize_features(
 
 def _split_data(
     data: pd.DataFrame, test_size: float, rng: np.random.Generator
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Split the data into training and test data.
 
     Args:

--- a/numerical_illustration/tasks/save_results.py
+++ b/numerical_illustration/tasks/save_results.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -8,11 +8,11 @@ import pandas as pd
 def save_results(
     train_data: pd.DataFrame,
     test_data: pd.DataFrame,
-    loss_results: Dict[str, Dict[str, List[float]]],
+    loss_results: dict[str, dict[str, list[float]]],
     metrics_mean: pd.DataFrame,
     metrics_std: pd.DataFrame,
     mean_rank: pd.DataFrame,
-    models: Dict[str, Any],
+    models: dict[str, Any],
     output_path: str,
 ) -> None:
     train_data.to_csv(os.path.join(output_path, "train_data.csv"), index=False)
@@ -45,7 +45,7 @@ def _save_metrics(
 
 
 def _save_tuning_results(
-    loss_results: Dict[str, Dict[str, List[float]]], output_path: str
+    loss_results: dict[str, dict[str, list[float]]], output_path: str
 ) -> None:
     if not loss_results:
         return
@@ -62,7 +62,7 @@ def _save_tuning_results(
             df_loss.to_csv(os.path.join(dataset_folder, f"{model_name}_loss.csv"), index=True)
 
 
-def _save_feature_importances(models: Dict[str, Any], output_path: str) -> None:
+def _save_feature_importances(models: dict[str, Any], output_path: str) -> None:
     feature_importances_folder = os.path.join(output_path, "feature_importances")
     os.makedirs(feature_importances_folder, exist_ok=True)
     for model_name, model in models.items():

--- a/numerical_illustration/tasks/setup_pipeline_run.py
+++ b/numerical_illustration/tasks/setup_pipeline_run.py
@@ -1,6 +1,5 @@
 import os
 import time
-from typing import Tuple
 
 import numpy as np
 import yaml
@@ -10,7 +9,7 @@ from ..schema import NumericalIllustrationConfig
 
 def setup_pipeline_run(
     config_path: str,
-) -> Tuple[NumericalIllustrationConfig, np.random.Generator, str]:
+) -> tuple[NumericalIllustrationConfig, np.random.Generator, str]:
     """
     Setup the pipeline run.
 

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,7 @@ def tune_models(
     train_data: pd.DataFrame,
     rng: np.random.Generator,
     log_prefix: str = "",
-) -> Tuple[Dict[str, pd.DataFrame], Dict[str, List[int]]]:
+) -> tuple[dict[str, pd.DataFrame], dict[str, list[int]]]:
     distribution = config.data.distribution_object
     X_train, y_train, w_train = get_targets_features(train_data)
     loss_results = {}
@@ -118,7 +118,7 @@ def _tune_ngboost(
     n_folds: int,
     rng: np.random.Generator,
     log_prefix: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Tune NGBoost n_estimators via k-fold CV using staged_pred_dist,
     mirroring the same fold split and loss computation as CGBM tuning."""
     folds = _fold_split(X=X, y=y, w=w, n_splits=n_folds, rng=rng)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     install_requires=requirements,
     license="MIT",
     license_files=("LICENSE",),


### PR DESCRIPTION
## Summary

Migrate all type annotations from `typing` module generics to native Python type hints (PEP 585 + PEP 604).

## Changes

### `setup.py`
- Bumped `python_requires` from `">=3.7"` to `">=3.10"` to support native union syntax (`X | Y`).

### Type hint replacements across 16 source files
- `List[X]` → `list[X]`
- `Dict[K, V]` → `dict[K, V]`
- `Tuple[X, ...]` → `tuple[X, ...]`
- `Type` → `type`
- `Union[X, Y]` → `X | Y`
- `Optional[X]` → `X | None`

### Import cleanup
- **10 files** had their `from typing import ...` line removed entirely (all imported types were replaceable).
- **6 files** had their import trimmed to only non-replaceable types (`Any`, `Callable`, `Annotated`, `Literal`, `Self`).
- **1 file** (`schema/data.py`) was untouched — it only imports `Literal`.

## Validation

- All 12 tests pass.
- All modified files compile cleanly with `py_compile`.
- Grep confirms zero remaining instances of `List[`, `Dict[`, `Tuple[`, `Union[`, `Optional[`, `Type[` in the codebase.
