### PR TITLE
[Feature] Experimental categorical feature support via sklearn PR #33354

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,16 @@ currently does not support native categorical splits. There is an
 that adds this functionality. **Once that PR is merged and released, this
 workaround will no longer be required.**
 
-Until then, you can install scikit-learn from that PR branch to experiment with
-categorical features:
+### Caveats
+
+- `cyc-gbm` itself does not yet pass `categorical_features` through to the
+  underlying `DecisionTreeRegressor`. Code changes are needed before categorical
+  splits are actually used during fitting.
+- This is experimental and depends on an unmerged PR — the API may change.
+
+### Installation
+
+Install scikit-learn from the PR branch to get categorical support:
 
 ```bash
 uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@nocats-v2" --force-reinstall
@@ -77,16 +85,6 @@ uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@
 > ```bash
 > uv pip install scikit-learn==1.8.0 --force-reinstall
 > ```
-
-### Caveats
-
-The `BoostingTree._adjust_node_values` method traverses the fitted tree
-manually using `X[:, feature] <= threshold`, which is the standard numerical
-split routing. With the categorical PR, categorical nodes use bitset-based
-routing instead. This means that **the node value optimisation step in cyc-gbm
-will not correctly route samples through categorical split nodes**. Adapting
-`_adjust_node_values` to handle categorical splits is required before this can
-be used in practice and is tracked as future work.
 
 ## Contact
 If you have any questions, feel free to contact me [here](mailto:henning.zakrisson@gmail.com).

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@
 > uv pip install scikit-learn==1.8.0 --force-reinstall
 > ```
 
+After installing the PR branch, use `.venv/bin/python` to run scripts — **not**
+`uv run`. `uv run` re-syncs dependencies from `pyproject.toml` and will
+downgrade scikit-learn back to `1.8.0`, undoing the workaround.
+
 This is experimental and depends on an unmerged PR — the API may change.
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -54,5 +54,39 @@ loss = model.distribution.loss(y=y_test, z=model.predict(X_test)).sum()
 print(f'negative log likelihood: {loss}')
 ```
 
+## Experimental: Categorical feature support
+
+The base learner in `cyc-gbm` is scikit-learn's `DecisionTreeRegressor`, which
+currently does not support native categorical splits. There is an
+[open PR (scikit-learn #33354)](https://github.com/scikit-learn/scikit-learn/pull/33354)
+that adds this functionality. **Once that PR is merged and released, this
+workaround will no longer be required.**
+
+Until then, you can install scikit-learn from that PR branch to experiment with
+categorical features:
+
+```bash
+uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@nocats-v2" --force-reinstall
+```
+
+> **Note:** This builds scikit-learn from source (C/Cython compilation) and
+> requires a C compiler. On macOS this is included in the Xcode Command Line
+> Tools (`xcode-select --install`); on Linux install `gcc`/`g++` from your
+> package manager. The build takes roughly 5–15 minutes. To revert to the stable
+> release, run:
+> ```bash
+> uv pip install scikit-learn==1.8.0 --force-reinstall
+> ```
+
+### Caveats
+
+The `BoostingTree._adjust_node_values` method traverses the fitted tree
+manually using `X[:, feature] <= threshold`, which is the standard numerical
+split routing. With the categorical PR, categorical nodes use bitset-based
+routing instead. This means that **the node value optimisation step in cyc-gbm
+will not correctly route samples through categorical split nodes**. Adapting
+`_adjust_node_values` to handle categorical splits is required before this can
+be used in practice and is tracked as future work.
+
 ## Contact
 If you have any questions, feel free to contact me [here](mailto:henning.zakrisson@gmail.com).

--- a/README.md
+++ b/README.md
@@ -62,16 +62,7 @@ currently does not support native categorical splits. There is an
 that adds this functionality. **Once that PR is merged and released, this
 workaround will no longer be required.**
 
-### Caveats
-
-- `cyc-gbm` itself does not yet pass `categorical_features` through to the
-  underlying `DecisionTreeRegressor`. Code changes are needed before categorical
-  splits are actually used during fitting.
-- This is experimental and depends on an unmerged PR — the API may change.
-
-### Installation
-
-Install scikit-learn from the PR branch to get categorical support:
+To experiment with categorical features, install scikit-learn from the PR branch:
 
 ```bash
 uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@nocats-v2" --force-reinstall
@@ -85,6 +76,8 @@ uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@
 > ```bash
 > uv pip install scikit-learn==1.8.0 --force-reinstall
 > ```
+
+This is experimental and depends on an unmerged PR — the API may change.
 
 ## Contact
 If you have any questions, feel free to contact me [here](mailto:henning.zakrisson@gmail.com).

--- a/cyc_gbm/boosting_tree.py
+++ b/cyc_gbm/boosting_tree.py
@@ -33,6 +33,7 @@ class BoostingTree(DecisionTreeRegressor):
         :param min_samples_leaf: The minimum number of samples required to be at a leaf node.
         :param categorical_features: Indices of categorical features within the feature subset.
         """
+        categorical_features = categorical_features or []
         init_kwargs = dict(
             max_depth=max_depth,
             min_samples_split=min_samples_split,
@@ -41,7 +42,7 @@ class BoostingTree(DecisionTreeRegressor):
         if categorical_features:
             init_kwargs["categorical_features"] = categorical_features
         super().__init__(**init_kwargs)
-        self.categorical_features = categorical_features or []
+        self.categorical_features = categorical_features
         self.distribution = distribution
 
     def fit_gradients(

--- a/cyc_gbm/boosting_tree.py
+++ b/cyc_gbm/boosting_tree.py
@@ -22,6 +22,7 @@ class BoostingTree(DecisionTreeRegressor):
         max_depth: int,
         min_samples_split: int,
         min_samples_leaf: int,
+        categorical_features: list[int] | None = None,
     ):
         """
         Constructs a new BoostingTree instance.
@@ -30,12 +31,17 @@ class BoostingTree(DecisionTreeRegressor):
         :param max_depth: The maximum depth of the tree.
         :param min_samples_split: The minimum number of samples required to split an internal node.
         :param min_samples_leaf: The minimum number of samples required to be at a leaf node.
+        :param categorical_features: Indices of categorical features within the feature subset, or None.
         """
-        super().__init__(
+        init_kwargs = dict(
             max_depth=max_depth,
             min_samples_split=min_samples_split,
             min_samples_leaf=min_samples_leaf,
         )
+        if categorical_features is not None:
+            init_kwargs["categorical_features"] = categorical_features
+        super().__init__(**init_kwargs)
+        self.categorical_features = categorical_features
         self.distribution = distribution
 
     def fit_gradients(

--- a/cyc_gbm/boosting_tree.py
+++ b/cyc_gbm/boosting_tree.py
@@ -31,17 +31,17 @@ class BoostingTree(DecisionTreeRegressor):
         :param max_depth: The maximum depth of the tree.
         :param min_samples_split: The minimum number of samples required to split an internal node.
         :param min_samples_leaf: The minimum number of samples required to be at a leaf node.
-        :param categorical_features: Indices of categorical features within the feature subset, or None.
+        :param categorical_features: Indices of categorical features within the feature subset.
         """
         init_kwargs = dict(
             max_depth=max_depth,
             min_samples_split=min_samples_split,
             min_samples_leaf=min_samples_leaf,
         )
-        if categorical_features is not None:
+        if categorical_features:
             init_kwargs["categorical_features"] = categorical_features
         super().__init__(**init_kwargs)
-        self.categorical_features = categorical_features
+        self.categorical_features = categorical_features or []
         self.distribution = distribution
 
     def fit_gradients(
@@ -63,7 +63,53 @@ class BoostingTree(DecisionTreeRegressor):
         """
         g = self.distribution.grad(y=y, z=z, w=w, j=j)
         self.fit(X, -g)
+        if self.categorical_features:
+            X = self._encode_categorical_columns(X)
         self._adjust_node_values(X=X, y=y, z=z, w=w, j=j)
+
+    def _encode_categorical_columns(self, X: np.ndarray) -> np.ndarray:
+        """Encode categorical columns using the encoder fitted by sklearn during fit().
+
+        :param X: Input data (may contain raw categorical values).
+        :return: Copy of X with categorical columns replaced by integer codes.
+        """
+        X = X.copy()
+        X_cat = X[:, self.categorical_features]
+        if X_cat.ndim == 1:
+            X_cat = X_cat.reshape(-1, 1)
+        X_cat_encoded = self._categorical_encoder.transform(X_cat)
+        X[:, self.categorical_features] = X_cat_encoded
+        return X
+
+    @staticmethod
+    def _split_numerical(X: np.ndarray, feature: int, threshold: float) -> np.ndarray:
+        """Compute boolean mask for samples going to the left child at a numerical split.
+
+        :param X: Input data of shape (n_samples, n_features).
+        :param feature: Feature index used for the split.
+        :param threshold: Split threshold.
+        :return: Boolean array where True means the sample goes left.
+        """
+        return X[:, feature] <= threshold
+
+    @staticmethod
+    def _split_categorical(
+        X: np.ndarray, feature: int, bitset: np.ndarray
+    ) -> np.ndarray:
+        """Compute boolean mask for samples going to the left child at a categorical split.
+
+        Uses the bitset stored by sklearn's tree: bit k set means category k goes left.
+
+        :param X: Input data of shape (n_samples, n_features), with integer-encoded categoricals.
+        :param feature: Feature index used for the split.
+        :param bitset: Array of shape (8,) with dtype uint32 — the left_cat_bitset for this node.
+        :return: Boolean array where True means the sample goes left.
+        """
+        cat_values = X[:, feature].astype(np.intp)
+        word_idx = cat_values >> 5       # cat_value // 32
+        bit_idx = cat_values & 31        # cat_value % 32
+        words = bitset[word_idx]
+        return ((words >> bit_idx) & 1).astype(bool)
 
     def _adjust_node_values(
         self,
@@ -102,8 +148,12 @@ class BoostingTree(DecisionTreeRegressor):
         if feature == -2:
             # This is a leaf
             return
-        threshold = self.tree_.threshold[node_index]
-        index_left = X[:, feature] <= threshold
+        if feature in self.categorical_features:
+            bitset = self.tree_.left_cat_bitset[node_index]
+            index_left = self._split_categorical(X, feature, bitset)
+        else:
+            threshold = self.tree_.threshold[node_index]
+            index_left = self._split_numerical(X, feature, threshold)
         child_left = self.tree_.children_left[node_index]
         child_right = self.tree_.children_right[node_index]
         self._adjust_node_values(

--- a/cyc_gbm/cyc_gbm.py
+++ b/cyc_gbm/cyc_gbm.py
@@ -4,7 +4,6 @@ import logging
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
-from sklearn.tree import DecisionTreeRegressor
 
 from cyc_gbm.utils.distributions import Distribution, initiate_distribution
 from cyc_gbm.utils.utils import calculate_progress
@@ -12,10 +11,6 @@ from cyc_gbm.utils.fix_datatype import fix_datatype
 from cyc_gbm.boosting_tree import BoostingTree
 
 logger = logging.getLogger(__name__)
-
-_SKLEARN_HAS_CATEGORICAL = "categorical_features" in inspect.signature(
-    DecisionTreeRegressor.__init__
-).parameters
 
 class CyclicalGradientBooster:
     """
@@ -62,9 +57,8 @@ class CyclicalGradientBooster:
         self.feature_selection = feature_selection
 
         self.z0 = 0
-        self.trees = self._initialize_trees()
-        self.feature_names = None
-        self.n_features = None
+        self.trees = None
+        self._feature_names = None
 
     def _setup_hyper_parameter(self, hyper_parameter) -> list:
         """
@@ -95,10 +89,8 @@ class CyclicalGradientBooster:
                     min_samples_split=self.min_samples_split[j],
                     min_samples_leaf=self.min_samples_leaf[j],
                     categorical_features=self._categorical_features_for_subset(
-                        self.feature_selection[j]
-                    )
-                    if hasattr(self, "_categorical_features")
-                    else None,
+                        self._feature_selection[j]
+                    ),
                 )
                 for _ in range(self.n_estimators[j])
             ]
@@ -133,10 +125,10 @@ class CyclicalGradientBooster:
             for j in range(self.n_dim):
                 if k < self.n_estimators[j]:
                     self.trees[j][k].fit_gradients(
-                        X=X[:, self.feature_selection[j]], y=y, z=z, w=w, j=j
+                        X=X[:, self._feature_selection[j]], y=y, z=z, w=w, j=j
                     )
                     z[j] += self.learning_rate[j] * self.trees[j][k].predict(
-                        X[:, self.feature_selection[j]]
+                        X[:, self._feature_selection[j]]
                     )
 
                     # Log progress
@@ -167,44 +159,57 @@ class CyclicalGradientBooster:
         Categorical features (pd.CategoricalDtype columns) are detected and stored.
         """
         if isinstance(X, pd.DataFrame):
-            self.feature_names = list(X.columns)
+            self._feature_names = list(X.columns)
             self._categorical_features = {
                 col
                 for col in X.columns
                 if isinstance(X[col].dtype, pd.CategoricalDtype)
             }
             if self.feature_selection is not None:
-                self.feature_selection = [
+                self._feature_selection = [
                     [X.columns.get_loc(f) for f in self.feature_selection[j]]
                     for j in range(self.n_dim)
                 ]
+            else:
+                self._feature_selection = None
         else:
-            self.feature_names = list(np.arange(X.shape[1]))
+            self._feature_names = list(np.arange(X.shape[1]))
             self._categorical_features = set()
-        if self.feature_selection is None:
-            self.feature_selection = [
+            self._feature_selection = None
+        if self._feature_selection is None:
+            self._feature_selection = [
                 list(range(X.shape[1])) for j in range(self.n_dim)
             ]
-        self.n_features = X.shape[1]
         if self._categorical_features:
             self._check_categorical_support()
+
+    @property
+    def _n_features(self) -> int | None:
+        """Number of features, derived from stored feature names."""
+        return len(self._feature_names) if self._feature_names else None
 
     @staticmethod
     def _check_categorical_support() -> None:
         """Raise if the installed scikit-learn does not support categorical features."""
-        if not _SKLEARN_HAS_CATEGORICAL:
-            raise RuntimeError(
+        from sklearn.tree import DecisionTreeRegressor
+
+        has_support = "categorical_features" in inspect.signature(
+            DecisionTreeRegressor.__init__
+        ).parameters
+        if not has_support:
+            msg = (
                 "The installed version of scikit-learn does not support categorical "
                 "features in DecisionTreeRegressor. Install the branch from "
                 "https://github.com/scikit-learn/scikit-learn/pull/33354 :\n\n"
                 '  uv pip install "scikit-learn @ git+https://github.com/adam2392/'
                 'scikit-learn.git@nocats-v2" --force-reinstall'
             )
+            raise RuntimeError(msg)
 
     def _categorical_features_for_subset(self, feature_indices: list[int]) -> list[int] | None:
         """Map categorical feature names to positions within a feature subset.
 
-        :param feature_indices: Column indices for the subset (from feature_selection[j]).
+        :param feature_indices: Column indices for the subset (from _feature_selection[j]).
         :return: List of positions within the subset that are categorical, or None if empty.
         """
         if not self._categorical_features:
@@ -212,7 +217,7 @@ class CyclicalGradientBooster:
         positions = [
             i
             for i, col_idx in enumerate(feature_indices)
-            if self.feature_names[col_idx] in self._categorical_features
+            if self._feature_names[col_idx] in self._categorical_features
         ]
         return positions if positions else None
 
@@ -254,7 +259,7 @@ class CyclicalGradientBooster:
         :param z: Current predictions of the model. If None, the current predictions are calculated.
         :param w: Weights for the training data, of shape (n_samples,). Default is 1 for all samples.
         """
-        X, y, w = fix_datatype(X=X, y=y, w=w, feature_names=self.feature_names)
+        X, y, w = fix_datatype(X=X, y=y, w=w, feature_names=self._feature_names)
         if z is None:
             z = self.predict(X)
         self.trees[j].append(
@@ -264,12 +269,12 @@ class CyclicalGradientBooster:
                 min_samples_split=self.min_samples_split[j],
                 min_samples_leaf=self.min_samples_leaf[j],
                 categorical_features=self._categorical_features_for_subset(
-                    self.feature_selection[j]
+                    self._feature_selection[j]
                 ),
             )
         )
         self.trees[j][-1].fit_gradients(
-            X=X[:, self.feature_selection[j]], y=y, z=z, w=w, j=j
+            X=X[:, self._feature_selection[j]], y=y, z=z, w=w, j=j
         )
         self.n_estimators[j] += 1
 
@@ -282,13 +287,13 @@ class CyclicalGradientBooster:
         :param X: Input data matrix of shape (n_samples, n_features).
         :return: Predicted response values of shape (d,n_samples).
         """
-        X = fix_datatype(X=X, feature_names=self.feature_names)
+        X = fix_datatype(X=X, feature_names=self._feature_names)
         return self.z0[:, None] + np.array(
             [
                 self.learning_rate[j]
                 * np.sum(
                     [
-                        tree.predict(X[:, self.feature_selection[j]])
+                        tree.predict(X[:, self._feature_selection[j]])
                         for tree in self.trees[j]
                     ],
                     axis=0,
@@ -309,29 +314,29 @@ class CyclicalGradientBooster:
         :return: Feature importance of shape (n_features,)
         """
         if j == "all":
-            feature_importances = np.zeros(self.n_features)
+            feature_importances = np.zeros(self._n_features)
             for j in range(self.n_dim):
                 feature_importances_from_trees = np.array(
                     [tree.compute_feature_importances() for tree in self.trees[j]]
                 ).sum(axis=0)
                 feature_importances[
-                    self.feature_selection[j]
+                    self._feature_selection[j]
                 ] += feature_importances_from_trees
         else:
-            feature_importances = np.zeros(self.n_features)
+            feature_importances = np.zeros(self._n_features)
             feature_importances_from_trees = np.array(
                 [tree.compute_feature_importances() for tree in self.trees[j]]
             ).sum(axis=0)
 
             feature_importances[
-                self.feature_selection[j]
+                self._feature_selection[j]
             ] = feature_importances_from_trees
         if normalize:
             feature_importances /= feature_importances.sum()
 
         return {
-            self.feature_names[i]: feature_importances[i]
-            for i in range(self.n_features)
+            self._feature_names[i]: feature_importances[i]
+            for i in range(self._n_features)
         }
 
     def reset(self, n_estimators: int | list[int] | None = None) -> None:
@@ -347,8 +352,6 @@ class CyclicalGradientBooster:
                 else n_estimators
             )
 
-        self.trees = self._initialize_trees()
-
+        self.trees = None
         self.z0 = None
-        self.n_features = None
-        self.feature_names = None
+        self._feature_names = None

--- a/cyc_gbm/cyc_gbm.py
+++ b/cyc_gbm/cyc_gbm.py
@@ -206,20 +206,19 @@ class CyclicalGradientBooster:
             )
             raise RuntimeError(msg)
 
-    def _categorical_features_for_subset(self, feature_indices: list[int]) -> list[int] | None:
+    def _categorical_features_for_subset(self, feature_indices: list[int]) -> list[int]:
         """Map categorical feature names to positions within a feature subset.
 
         :param feature_indices: Column indices for the subset (from _feature_selection[j]).
-        :return: List of positions within the subset that are categorical, or None if empty.
+        :return: List of positions within the subset that are categorical.
         """
         if not self._categorical_features:
-            return None
-        positions = [
+            return []
+        return [
             i
             for i, col_idx in enumerate(feature_indices)
             if self._feature_names[col_idx] in self._categorical_features
         ]
-        return positions if positions else None
 
     def initialize_estimate(
         self,

--- a/cyc_gbm/cyc_gbm.py
+++ b/cyc_gbm/cyc_gbm.py
@@ -1,8 +1,10 @@
+import inspect
 import logging
 
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
+from sklearn.tree import DecisionTreeRegressor
 
 from cyc_gbm.utils.distributions import Distribution, initiate_distribution
 from cyc_gbm.utils.utils import calculate_progress
@@ -10,6 +12,10 @@ from cyc_gbm.utils.fix_datatype import fix_datatype
 from cyc_gbm.boosting_tree import BoostingTree
 
 logger = logging.getLogger(__name__)
+
+_SKLEARN_HAS_CATEGORICAL = "categorical_features" in inspect.signature(
+    DecisionTreeRegressor.__init__
+).parameters
 
 class CyclicalGradientBooster:
     """
@@ -88,6 +94,11 @@ class CyclicalGradientBooster:
                     max_depth=self.max_depth[j],
                     min_samples_split=self.min_samples_split[j],
                     min_samples_leaf=self.min_samples_leaf[j],
+                    categorical_features=self._categorical_features_for_subset(
+                        self.feature_selection[j]
+                    )
+                    if hasattr(self, "_categorical_features")
+                    else None,
                 )
                 for _ in range(self.n_estimators[j])
             ]
@@ -110,6 +121,7 @@ class CyclicalGradientBooster:
         :param verbose: Whether to log progress.
         """
         self._initialize_feature_metadata(X=X)
+        self.trees = self._initialize_trees()
         X, y, w = fix_datatype(X=X, y=y, w=w)
 
         self.z0 = self.initialize_estimate(y=y, w=w)
@@ -152,9 +164,15 @@ class CyclicalGradientBooster:
         If the input data is a DataFrame, the column names are returned.
         Otherwise, the features are named 0, 1, ..., p-1.
         The feature selection is fixed to comply with the numpy array format.
+        Categorical features (pd.CategoricalDtype columns) are detected and stored.
         """
         if isinstance(X, pd.DataFrame):
             self.feature_names = list(X.columns)
+            self._categorical_features = {
+                col
+                for col in X.columns
+                if isinstance(X[col].dtype, pd.CategoricalDtype)
+            }
             if self.feature_selection is not None:
                 self.feature_selection = [
                     [X.columns.get_loc(f) for f in self.feature_selection[j]]
@@ -162,11 +180,41 @@ class CyclicalGradientBooster:
                 ]
         else:
             self.feature_names = list(np.arange(X.shape[1]))
+            self._categorical_features = set()
         if self.feature_selection is None:
             self.feature_selection = [
                 list(range(X.shape[1])) for j in range(self.n_dim)
             ]
         self.n_features = X.shape[1]
+        if self._categorical_features:
+            self._check_categorical_support()
+
+    @staticmethod
+    def _check_categorical_support() -> None:
+        """Raise if the installed scikit-learn does not support categorical features."""
+        if not _SKLEARN_HAS_CATEGORICAL:
+            raise RuntimeError(
+                "The installed version of scikit-learn does not support categorical "
+                "features in DecisionTreeRegressor. Install the branch from "
+                "https://github.com/scikit-learn/scikit-learn/pull/33354 :\n\n"
+                '  uv pip install "scikit-learn @ git+https://github.com/adam2392/'
+                'scikit-learn.git@nocats-v2" --force-reinstall'
+            )
+
+    def _categorical_features_for_subset(self, feature_indices: list[int]) -> list[int] | None:
+        """Map categorical feature names to positions within a feature subset.
+
+        :param feature_indices: Column indices for the subset (from feature_selection[j]).
+        :return: List of positions within the subset that are categorical, or None if empty.
+        """
+        if not self._categorical_features:
+            return None
+        positions = [
+            i
+            for i, col_idx in enumerate(feature_indices)
+            if self.feature_names[col_idx] in self._categorical_features
+        ]
+        return positions if positions else None
 
     def initialize_estimate(
         self,
@@ -215,6 +263,9 @@ class CyclicalGradientBooster:
                 max_depth=self.max_depth[j],
                 min_samples_split=self.min_samples_split[j],
                 min_samples_leaf=self.min_samples_leaf[j],
+                categorical_features=self._categorical_features_for_subset(
+                    self.feature_selection[j]
+                ),
             )
         )
         self.trees[j][-1].fit_gradients(


### PR DESCRIPTION
## Summary

Adds experimental support for categorical features, leveraging the open [scikit-learn PR #33354](https://github.com/scikit-learn/scikit-learn/pull/33354) which adds native categorical splits to `DecisionTreeRegressor`. Once that PR is merged and released, the sklearn install workaround documented here will no longer be required.

## Changes

### Documentation (`README.md`)
- New "Experimental: Categorical feature support" section
- Install command for the sklearn PR branch, build prerequisites, revert instructions
- Caveat that this depends on an unmerged PR

### Categorical feature detection (`cyc_gbm.py`)
- `_initialize_feature_metadata` detects `pd.CategoricalDtype` columns and stores them as `_categorical_features: set[str]`
- `_categorical_features_for_subset` remaps categorical column names to positions within each dimension's `feature_selection` subset
- `_check_categorical_support` raises `RuntimeError` with install instructions if categoricals are detected but sklearn lacks support
- `_initialize_trees` and `add_tree` pass `categorical_features` through to `BoostingTree`

### Categorical split routing (`boosting_tree.py`)
- `BoostingTree.__init__` accepts `categorical_features` and forwards to `DecisionTreeRegressor` when non-empty
- After `self.fit(X, -g)`, `fit_gradients` encodes categorical columns using sklearn's own fitted `_categorical_encoder` — guaranteeing the integer codes match the tree's internal representation
- `_adjust_node_values` dispatches to helper functions for routing samples through the tree:
  - `_split_numerical`: standard `X[:, feature] <= threshold`
  - `_split_categorical`: reads the `left_cat_bitset` from the fitted tree and checks bit membership

### Refactoring (`cyc_gbm.py`)
- `feature_names` → `_feature_names`, resolved `feature_selection` → `_feature_selection` (constructor param stays public)
- `_n_features` is now a `@property` derived from `_feature_names`
- Tree pre-allocation removed from `__init__` (created in `fit()`)

## Usage

Requires installing sklearn from the PR branch (builds from source, needs a C compiler):

```bash
uv pip install "scikit-learn @ git+https://github.com/adam2392/scikit-learn.git@nocats-v2" --force-reinstall
```

Input DataFrames must use `pd.CategoricalDtype` for categorical columns:

```python
X = pd.DataFrame({"x_cont": x_cont, "colour": pd.Categorical(["red", "green", "blue", ...])})
```

**Important:** Use `.venv/bin/python` to run scripts — `uv run` will re-sync dependencies and downgrade sklearn back to `1.8.0`.

## Not included

- End-to-end test with the sklearn PR branch (requires manual install)
- Example script at `scripts/categorical_example.py` (uncommitted, in `.gitignore`)
