### PR TITLE
[Chore] Add missing type hints across codebase

### DIFF
--- a/cyc_gbm/boosting_tree.py
+++ b/cyc_gbm/boosting_tree.py
@@ -23,7 +23,7 @@ class BoostingTree(DecisionTreeRegressor):
         min_samples_split: int,
         min_samples_leaf: int,
         categorical_features: list[int] | None = None,
-    ):
+    ) -> None:
         """
         Constructs a new BoostingTree instance.
 
@@ -181,7 +181,7 @@ class BoostingTree(DecisionTreeRegressor):
         w: np.ndarray,
         j: int,
         node_value_0: float = 0,
-    ):
+    ) -> float:
         """
         Numerically optimize the node value for the data in specified dimension
 

--- a/cyc_gbm/cyc_gbm.py
+++ b/cyc_gbm/cyc_gbm.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from typing import TypeVar
 
 import numpy as np
 import pandas as pd
@@ -9,6 +10,8 @@ from cyc_gbm.utils.distributions import Distribution, initiate_distribution
 from cyc_gbm.utils.utils import calculate_progress
 from cyc_gbm.utils.fix_datatype import fix_datatype
 from cyc_gbm.boosting_tree import BoostingTree
+
+HyperParameter = TypeVar("HyperParameter", int, float)
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +63,7 @@ class CyclicalGradientBooster:
         self.trees = None
         self._feature_names = None
 
-    def _setup_hyper_parameter(self, hyper_parameter) -> list:
+    def _setup_hyper_parameter(self, hyper_parameter: HyperParameter | list[HyperParameter] | np.ndarray) -> list[HyperParameter]:
         """
         Initialize parameter to default_value if parameter is not a list or numpy array.
 
@@ -77,7 +80,7 @@ class CyclicalGradientBooster:
             )
         return hyper_parameter_list
 
-    def _initialize_trees(self):
+    def _initialize_trees(self) -> list[list[BoostingTree]]:
         """
         Initialize trees for each parameter dimension.
         """
@@ -138,7 +141,7 @@ class CyclicalGradientBooster:
         # Adjust initial estimate given current tree estimates
         self.z0 += self.initialize_estimate(y=y, w=w, z=z)
 
-    def _log_progress(self, step: int, total_steps: int,last_progress: float = -1) -> None:
+    def _log_progress(self, step: int, total_steps: int, last_progress: float = -1) -> float:
         """
         Log the progress of the simulation.
 
@@ -305,7 +308,7 @@ class CyclicalGradientBooster:
 
     def compute_feature_importances(
         self, j: str | int = "all", normalize: bool = True
-    ) -> np.ndarray | pd.Series:
+    ) -> dict[str | int, float]:
         """
         Computes the feature importances for parameter dimension j
 

--- a/cyc_gbm/utils/distributions.py
+++ b/cyc_gbm/utils/distributions.py
@@ -44,7 +44,7 @@ class Distribution:
     def __init__(
         self,
         n_dim: int | None = None,
-    ):
+    ) -> None:
         """Initialize a distribution object."""
         self.n_dim = n_dim
 
@@ -117,7 +117,7 @@ class Distribution:
 class MultivariateNormalDistribution(Distribution):
     def __init__(
         self,
-    ):
+    ) -> None:
         """Initialize a multivariate normal distribution object with equal means and variances and
         correlation
 
@@ -246,7 +246,7 @@ class MultivariateNormalDistribution(Distribution):
 class NormalDistribution(Distribution):
     def __init__(
         self,
-    ):
+    ) -> None:
         """Initialize a normal distribution object.
 
         Parameterization: z[0] = mu, z[1] = log(sigma), where E[Y] = w*mu, Var(Y) = w*sigma^2
@@ -301,7 +301,7 @@ class NormalDistribution(Distribution):
 class NegativeBinomialDistribution(Distribution):
     def __init__(
         self,
-    ):
+    ) -> None:
         """Initialize a negative binomial distribution object.
 
         Parameterization: z[0] = np.log(mu), z[1] = log(theta), where E[Y] = w*mu, Var(Y) = w*mu*(1+mu/theta)
@@ -375,7 +375,7 @@ class NegativeBinomialDistribution(Distribution):
 class InverseGaussianDistribution(Distribution):
     def __init__(
         self,
-    ):
+    ) -> None:
         """Initialize a inverse Gaussian distribution object.
 
         Parameterization: z[0] = log(mu), z[1] = log(lambda), where E[Y] = w*mu, Var(Y) =w*mu^3 / lambda
@@ -452,7 +452,7 @@ class InverseGaussianDistribution(Distribution):
 class GammaDistribution(Distribution):
     def __init__(
         self,
-    ):
+    ) -> None:
         """
         Initialize a gamma distribution object.
 
@@ -524,7 +524,7 @@ class GammaDistribution(Distribution):
 class BetaPrimeDistribution(Distribution):
     def __init__(
         self,
-    ):
+    ) -> None:
         """
         Initialize a beta prime distribution object.
 
@@ -645,7 +645,7 @@ class CustomDistribution(Distribution):
         ],
         moment: Callable[[np.ndarray, int, np.ndarray | float], np.ndarray],
         d: int,
-    ):
+    ) -> None:
         """
         Initialize a custom distribution object.
 

--- a/cyc_gbm/utils/tuning.py
+++ b/cyc_gbm/utils/tuning.py
@@ -116,7 +116,7 @@ def _evaluate_fold(
     model: CyclicalGradientBooster,
     n_estimators_max: list[int],
     log_prefix: str = "",
-):
+) -> tuple[np.ndarray, np.ndarray]:
     X_train, y_train, w_train, X_valid, y_valid, w_valid = fold
 
     model.reset(n_estimators=0)

--- a/numerical_illustration/numerical_illustration.py
+++ b/numerical_illustration/numerical_illustration.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import logging
+from typing import Any
 
 from joblib import Parallel, delayed
 import numpy as np
@@ -41,7 +42,7 @@ def _run_single_iteration(
     iteration: int = 1,
     n_bootstraps: int = 1,
     log_prefix: str = "",
-):
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any], dict[str, Any], pd.DataFrame]:
     """Run one full simulation iteration: load, preprocess, tune, fit, predict, evaluate."""
     if n_bootstraps > 1:
         log_prefix = f"[bootstrap {iteration + 1}/{n_bootstraps}] "
@@ -84,7 +85,7 @@ def _format_metrics(mean: pd.DataFrame, std: pd.DataFrame) -> pd.DataFrame:
     return formatted
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Run the numerical illustration pipeline.")
     parser.add_argument(
         "--config",

--- a/numerical_illustration/tasks/baseline_models/cyc_glm.py
+++ b/numerical_illustration/tasks/baseline_models/cyc_glm.py
@@ -14,7 +14,7 @@ class CyclicGeneralizedLinearModel:
         max_iter: int = 1000,
         tol: float = 1e-5,
         eps: list[float] | float = 1e-7,
-    ):
+    ) -> None:
         """
         Initialize the model.
         """

--- a/numerical_illustration/tasks/baseline_models/ngboost_model.py
+++ b/numerical_illustration/tasks/baseline_models/ngboost_model.py
@@ -37,7 +37,7 @@ class NGBoostModel:
         learning_rate: float = 0.01,
         max_depth: int = 3,
         random_state: int = 0,
-    ):
+    ) -> None:
         if not isinstance(distribution, NormalDistribution):
             raise NotImplementedError(
                 f"NGBoost wrapper only supports NormalDistribution, "
@@ -76,7 +76,7 @@ class NGBoostModel:
         log_sigma = np.log(dist.scale)
         return np.stack([mu, log_sigma])
 
-    def compute_feature_importances(self, j=None):
+    def compute_feature_importances(self, j: str | int | None = None) -> np.ndarray:
         """Compute feature importances from the fitted NGBoost model.
 
         Args:

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -9,6 +9,7 @@ from ngboost.scores import MLE
 from sklearn.tree import DecisionTreeRegressor
 
 from cyc_gbm import CyclicalGradientBooster
+from cyc_gbm.utils.distributions import Distribution
 from cyc_gbm.utils.tuning import _fold_split, tune_n_estimators
 
 from ..schema import (
@@ -111,7 +112,7 @@ def _tune_ngboost(
     X: np.ndarray,
     y: np.ndarray,
     w: np.ndarray,
-    distribution,
+    distribution: Distribution,
     n_estimators_max: int,
     learning_rate: float,
     max_depth: int,

--- a/numerical_illustration/tasks/utils/utils.py
+++ b/numerical_illustration/tasks/utils/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 
-def get_targets_features(train_data: pd.DataFrame) -> np.ndarray:
+def get_targets_features(train_data: pd.DataFrame) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     features = [
         col
         for col in train_data.columns


### PR DESCRIPTION
## Summary

Add missing and fix incorrect type hints across the core `cyc_gbm` module and the `numerical_illustration` helper package.

## Changes

### Incorrect annotations fixed
- `CyclicalGradientBooster._log_progress`: return type `None` → `float` (it returns `last_progress`)
- `CyclicalGradientBooster.compute_feature_importances`: return type `np.ndarray | pd.Series` → `dict[str | int, float]` (returns a dict)
- `get_targets_features`: return type `np.ndarray` → `tuple[np.ndarray, np.ndarray, np.ndarray]` (returns a 3-tuple)

### Missing annotations added
- `_setup_hyper_parameter`: added `HyperParameter` TypeVar for param + return types
- `_initialize_trees`: added `-> list[list[BoostingTree]]`
- `BoostingTree._optimize_node_value`: added `-> float`
- `_evaluate_fold`: added `-> tuple[np.ndarray, np.ndarray]`
- `_run_single_iteration`: added full 5-tuple return type
- `main()`: added `-> None`
- `_tune_ngboost`: typed `distribution` param as `Distribution`
- `NGBoostModel.compute_feature_importances`: typed `j` param and return

### `-> None` on `__init__` methods
- All 7 distribution subclasses + `Distribution` base in `distributions.py`
- `BoostingTree`, `CyclicGeneralizedLinearModel`, `NGBoostModel`

## Validation

All 12 tests pass.
