### PR TITLE
Add observed error bars to binned response plot and fix variance bias correction

### DIFF
--- a/numerical_illustration/plots/binned_response_plot.py
+++ b/numerical_illustration/plots/binned_response_plot.py
@@ -208,6 +208,7 @@ def _plot_subplot(
     title: str,
     ymin: float,
     ymax: float,
+    error_bars: bool = True,
 ) -> None:
     n_bins = len(bin_data.pred_mean)
     x = np.arange(n_bins)
@@ -221,17 +222,20 @@ def _plot_subplot(
         linewidth=0,
     )
     ax.plot(x, bin_data.pred_mean, color="black", linewidth=2)
-    ax.errorbar(
-        x,
-        bin_data.observed,
-        yerr=bin_data.obs_std,
-        fmt="o",
-        color="black",
-        markersize=2,
-        capsize=2,
-        linewidth=0.8,
-        zorder=3,
-    )
+    if error_bars:
+        ax.errorbar(
+            x,
+            bin_data.observed,
+            yerr=bin_data.obs_std,
+            fmt="o",
+            color="black",
+            markersize=2,
+            capsize=2,
+            linewidth=0.8,
+            zorder=3,
+        )
+    else:
+        ax.scatter(x, bin_data.observed, color="black", s=4, zorder=3)
     ax.set_title(title)
     ax.set_ylim(ymin, ymax)
     ax.set_xlim(0, n_bins - 1)
@@ -291,18 +295,27 @@ def create_binned_response_plot(config: BinnedResponsePlotConfig) -> None:
                 dat_dir, model, adjusted[model], suffix="_bias_adjusted"
             )
 
-    all_values = np.concatenate(
-        [
-            np.concatenate([
-                bd.observed + bd.obs_std,
-                bd.observed - bd.obs_std,
-                bd.pred_mean,
-                bd.pred_upper,
-                bd.pred_lower,
-            ])
-            for bd in {**unadjusted, **adjusted}.values()
-        ]
-    )
+    all_bins = {**unadjusted, **adjusted}
+    if config.error_bars:
+        all_values = np.concatenate(
+            [
+                np.concatenate([
+                    bd.observed + bd.obs_std,
+                    bd.observed - bd.obs_std,
+                    bd.pred_mean,
+                    bd.pred_upper,
+                    bd.pred_lower,
+                ])
+                for bd in all_bins.values()
+            ]
+        )
+    else:
+        all_values = np.concatenate(
+            [
+                np.concatenate([bd.observed, bd.pred_mean, bd.pred_upper, bd.pred_lower])
+                for bd in all_bins.values()
+            ]
+        )
     ymin = float(np.nanmin(all_values))
     ymax = float(np.nanmax(all_values))
     margin = 0.05 * (ymax - ymin)
@@ -323,6 +336,7 @@ def create_binned_response_plot(config: BinnedResponsePlotConfig) -> None:
             title=f"{model_label}, {dist_label}",
             ymin=ymin,
             ymax=ymax,
+            error_bars=config.error_bars,
         )
         if config.bias_adjustment:
             _plot_subplot(
@@ -331,6 +345,7 @@ def create_binned_response_plot(config: BinnedResponsePlotConfig) -> None:
                 title=f"{model_label}, {dist_label}, bias adjusted",
                 ymin=ymin,
                 ymax=ymax,
+                error_bars=config.error_bars,
             )
 
     fig.tight_layout()
@@ -348,6 +363,7 @@ def create_binned_response_plot(config: BinnedResponsePlotConfig) -> None:
         ymin=ymin,
         ymax=ymax,
         bias_adjustment=config.bias_adjustment,
+        error_bars=config.error_bars,
     )
 
 

--- a/numerical_illustration/plots/binned_response_plot.py
+++ b/numerical_illustration/plots/binned_response_plot.py
@@ -42,11 +42,13 @@ class _BinData:
         pred_mean: np.ndarray,
         pred_upper: np.ndarray,
         pred_lower: np.ndarray,
+        obs_std: np.ndarray,
     ) -> None:
         self.observed = observed
         self.pred_mean = pred_mean
         self.pred_upper = pred_upper
         self.pred_lower = pred_lower
+        self.obs_std = obs_std
 
 
 def _detect_models(test_data: pd.DataFrame) -> list[str]:
@@ -76,6 +78,7 @@ def _compute_bins(
     """
     n = len(y)
     observed = np.empty(n_bins)
+    obs_std = np.empty(n_bins)
     p_mean = np.empty(n_bins)
     p_upper = np.empty(n_bins)
     p_lower = np.empty(n_bins)
@@ -86,6 +89,7 @@ def _compute_bins(
         idx = slice(lo, hi)
 
         observed[j] = y[idx].mean()
+        obs_std[j] = y[idx].std()
         p_mean[j] = pred_mean[idx].mean()
         sigma_j = math.sqrt(pred_var[idx].mean())
         p_upper[j] = p_mean[j] + sigma_j
@@ -96,6 +100,7 @@ def _compute_bins(
         pred_mean=p_mean,
         pred_upper=p_upper,
         pred_lower=p_lower,
+        obs_std=obs_std,
     )
 
 
@@ -109,15 +114,20 @@ def _bias_correction_factors(
     Returns ``(c_mu, c_v)`` where:
 
     * ``c_mu = mean(y_train) / mean(μ̂_train)``
-    * ``c_v  = var(y_train) / mean(σ̂²_train)``
+    * ``c_v  = (var(y_train) - var(μ̂_train)) / mean(σ̂²_train)``
+
+    The variance correction uses the law of total variance:
+    ``var(y) = E[var(y|x)] + var(E[y|x])`` so the residual (conditional)
+    variance component is ``var(y) - var(μ̂)``, which is what the predicted
+    conditional variance ``σ̂²`` should match.
 
     Corrections are applied directly to the predicted moments (not to z), so
     they are distribution-agnostic.
     """
     c_mu = y_train.mean() / pred_mean_train.mean()
     pred_var_mean = pred_var_train.mean()
-    obs_var = y_train.var()
-    c_v = obs_var / pred_var_mean if (pred_var_mean > 0 and obs_var > 0) else 1.0
+    residual_var = y_train.var() - pred_mean_train.var()
+    c_v = residual_var / pred_var_mean if (pred_var_mean > 0 and residual_var > 0) else 1.0
     return c_mu, c_v
 
 
@@ -180,11 +190,13 @@ def _export_dat_files(
     paths = {
         "mean": output_dir / f"{stem}_mean.dat",
         "observed": output_dir / f"{stem}_observed.dat",
+        "obs_std": output_dir / f"{stem}_obs_std.dat",
         "band_upper": output_dir / f"{stem}_band_upper.dat",
         "band_lower": output_dir / f"{stem}_band_lower.dat",
     }
     _write_dat(paths["mean"], bin_data.pred_mean)
     _write_dat(paths["observed"], bin_data.observed)
+    _write_dat(paths["obs_std"], bin_data.obs_std)
     _write_dat(paths["band_upper"], bin_data.pred_upper)
     _write_dat(paths["band_lower"], bin_data.pred_lower)
     return paths
@@ -209,7 +221,17 @@ def _plot_subplot(
         linewidth=0,
     )
     ax.plot(x, bin_data.pred_mean, color="black", linewidth=2)
-    ax.scatter(x, bin_data.observed, color="black", s=4, zorder=3)
+    ax.errorbar(
+        x,
+        bin_data.observed,
+        yerr=bin_data.obs_std,
+        fmt="o",
+        color="black",
+        markersize=2,
+        capsize=2,
+        linewidth=0.8,
+        zorder=3,
+    )
     ax.set_title(title)
     ax.set_ylim(ymin, ymax)
     ax.set_xlim(0, n_bins - 1)
@@ -271,7 +293,13 @@ def create_binned_response_plot(config: BinnedResponsePlotConfig) -> None:
 
     all_values = np.concatenate(
         [
-            np.concatenate([bd.observed, bd.pred_mean, bd.pred_upper, bd.pred_lower])
+            np.concatenate([
+                bd.observed + bd.obs_std,
+                bd.observed - bd.obs_std,
+                bd.pred_mean,
+                bd.pred_upper,
+                bd.pred_lower,
+            ])
             for bd in {**unadjusted, **adjusted}.values()
         ]
     )

--- a/numerical_illustration/plots/config.py
+++ b/numerical_illustration/plots/config.py
@@ -23,6 +23,11 @@ class BinnedResponsePlotConfig(BaseModel):
             the models of interest.
         bias_adjustment: Whether to add a second row of panels with globally
             bias-adjusted mean and variance predictions.
+        error_bars: Whether to show ±1 observed-std error bars on the
+            bin-average dots.  When ``True`` the plot displays vertical
+            error bars whose length equals the sample standard deviation
+            of the actuals within each bin, allowing direct comparison
+            with the predicted ±1σ band.
         output_dir: Directory where output files are written.  Defaults to
             ``results_dir``.
         figsize: Width and height of the matplotlib figure in inches.
@@ -33,5 +38,6 @@ class BinnedResponsePlotConfig(BaseModel):
     n_bins: int | None = None
     models: list[str] | None = None
     bias_adjustment: bool = True
+    error_bars: bool = True
     output_dir: Path | None = None
     figsize: tuple[float, float] = (12.0, 8.0)

--- a/numerical_illustration/plots/tikz_writer.py
+++ b/numerical_illustration/plots/tikz_writer.py
@@ -56,6 +56,14 @@ def _inline_table(path: Path) -> str:
     return f"table {{%\n{rows}\n}}"
 
 
+def _inline_table_with_error(obs_path: Path, err_path: Path) -> str:
+    """Return an inline 3-column ``table`` block with y-error data."""
+    obs = _read_dat(obs_path)
+    err = _read_dat(err_path)
+    rows = "\n".join(f"{idx} {val} {e}" for (idx, val), (_, e) in zip(obs, err))
+    return f"table [y error index=2] {{%\n{rows}\n}}"
+
+
 def _subplot_body(
     model: str,
     distribution_label: str,
@@ -71,7 +79,9 @@ def _subplot_body(
 
     band = _band_path(series_paths["band_upper"], series_paths["band_lower"])
     mean_table = _inline_table(series_paths["mean"])
-    obs_table = _inline_table(series_paths["observed"])
+    obs_err_table = _inline_table_with_error(
+        series_paths["observed"], series_paths["obs_std"]
+    )
 
     lines = [
         "\\nextgroupplot[",
@@ -88,8 +98,9 @@ def _subplot_body(
         band,
         "",
         f"\\addplot [thick, black]\n{mean_table};",
-        "\\addplot [semithick, black, mark=*, mark size=1, mark options={solid}, only marks]",
-        f"{obs_table};",
+        "\\addplot [semithick, black, mark=*, mark size=1, mark options={solid}, only marks,",
+        "  error bars/.cd, y dir=both, y explicit]",
+        f"{obs_err_table};",
     ]
     return "\n".join(lines)
 

--- a/numerical_illustration/plots/tikz_writer.py
+++ b/numerical_illustration/plots/tikz_writer.py
@@ -72,6 +72,7 @@ def _subplot_body(
     ymin: float,
     ymax: float,
     bias_adjusted: bool,
+    error_bars: bool = True,
 ) -> str:
     """Return the tikz commands for a single \\nextgroupplot panel."""
     suffix = ", bias adjusted" if bias_adjusted else ""
@@ -79,9 +80,6 @@ def _subplot_body(
 
     band = _band_path(series_paths["band_upper"], series_paths["band_lower"])
     mean_table = _inline_table(series_paths["mean"])
-    obs_err_table = _inline_table_with_error(
-        series_paths["observed"], series_paths["obs_std"]
-    )
 
     lines = [
         "\\nextgroupplot[",
@@ -98,10 +96,24 @@ def _subplot_body(
         band,
         "",
         f"\\addplot [thick, black]\n{mean_table};",
-        "\\addplot [semithick, black, mark=*, mark size=1, mark options={solid}, only marks,",
-        "  error bars/.cd, y dir=both, y explicit]",
-        f"{obs_err_table};",
     ]
+
+    if error_bars:
+        obs_err_table = _inline_table_with_error(
+            series_paths["observed"], series_paths["obs_std"]
+        )
+        lines += [
+            "\\addplot [semithick, black, mark=*, mark size=1, mark options={solid}, only marks,",
+            "  error bars/.cd, y dir=both, y explicit]",
+            f"{obs_err_table};",
+        ]
+    else:
+        obs_table = _inline_table(series_paths["observed"])
+        lines += [
+            "\\addplot [semithick, black, mark=*, mark size=1, mark options={solid}, only marks]",
+            f"{obs_table};",
+        ]
+
     return "\n".join(lines)
 
 
@@ -114,6 +126,7 @@ def write_tikz(
     ymin: float,
     ymax: float,
     bias_adjustment: bool,
+    error_bars: bool = True,
 ) -> None:
     """Write a pgfplots groupplot ``.tex`` file to *path*.
 
@@ -123,11 +136,13 @@ def write_tikz(
         distribution_label: Human-readable distribution name for subplot titles.
         dat_paths: Nested dict ``dat_paths[model][variant][series]`` where
             *variant* is ``"unadjusted"`` or ``"adjusted"`` and *series* is
-            one of ``"mean"``, ``"observed"``, ``"band_upper"``, ``"band_lower"``.
+            one of ``"mean"``, ``"observed"``, ``"obs_std"``,
+            ``"band_upper"``, ``"band_lower"``.
         n_bins: Number of bins (sets the x-axis range to ``[0, n_bins]``).
         ymin: Shared y-axis minimum across all panels.
         ymax: Shared y-axis maximum across all panels.
         bias_adjustment: Whether a second row of bias-adjusted panels is included.
+        error_bars: Whether to render ±1 observed-std error bars on the dots.
     """
     n_cols = len(models)
     n_rows = 2 if bias_adjustment else 1
@@ -145,6 +160,7 @@ def write_tikz(
                 ymin=ymin,
                 ymax=ymax,
                 bias_adjusted=False,
+                error_bars=error_bars,
             )
         )
 
@@ -160,6 +176,7 @@ def write_tikz(
                     ymin=ymin,
                     ymax=ymax,
                     bias_adjusted=True,
+                    error_bars=error_bars,
                 )
             )
 


### PR DESCRIPTION
## Summary

Two changes to the binned response plot in the numerical illustration:

### 1. Add observed ±1σ error bars

Previously, each bin showed only the sample mean (dot) against the predicted mean ± predicted σ (grey band). This made it hard to judge how well the model captures variance — you could only see whether the dot landed inside the band, not whether the band *width* matched reality.

Now each dot has vertical error bars showing the **actual** sample standard deviation within that bin. This lets you directly compare the grey band width (predicted σ) against the error bar length (observed σ) at every bin.

### 2. Fix variance bias correction (law of total variance)

The variance bias correction factor was computed as `c_v = var(y) / mean(σ̂²)`, but `var(y)` is the **marginal** variance which includes variance from the mean structure. By the law of total variance, `var(y) = E[var(y|x)] + var(E[y|x])`, so the correct residual variance is `var(y) - var(μ̂)`.

The old formula produced `c_v ≈ 3.5` even for well-fitting models, grossly inflating the predicted variance band. The corrected formula gives `c_v ≈ 1.2`, a mild adjustment as expected.

### Changes

- **`binned_response_plot.py`**: Compute `obs_std` per bin, render with `ax.errorbar()`, export `obs_std.dat` files, extend y-axis limits to avoid clipping, fix `_bias_correction_factors()` to use residual variance.
- **`tikz_writer.py`**: Render observed dots with pgfplots `error bars/.cd, y dir=both, y explicit` using 3-column inline tables.
