### PR TITLE
Add concentration curve plot tool

### DIFF
--- a/numerical_illustration/plots/__init__.py
+++ b/numerical_illustration/plots/__init__.py
@@ -1,9 +1,13 @@
 """Plotting utilities for the numerical illustration pipeline."""
 
 from .binned_response_plot import create_binned_response_plot
+from .concentration_config import ConcentrationCurvePlotConfig
+from .concentration_curve_plot import create_concentration_curve_plot
 from .config import BinnedResponsePlotConfig
 
 __all__ = [
     "BinnedResponsePlotConfig",
+    "ConcentrationCurvePlotConfig",
     "create_binned_response_plot",
+    "create_concentration_curve_plot",
 ]

--- a/numerical_illustration/plots/concentration_config.py
+++ b/numerical_illustration/plots/concentration_config.py
@@ -1,22 +1,30 @@
 """Configuration models for the concentration curve plot."""
 
-from pathlib import Path
+from __future__ import annotations
 
-from pydantic import BaseModel
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, Field
 
 from numerical_illustration.schema.constants import ModelClass
 
-# Default model colours matching the paper's concentration_curves.tex.
-DEFAULT_MODEL_COLORS: dict[str, str] = {
-    ModelClass.GBM: "#B0B0B0",       # lightgray (RGB 176,176,176)
-    ModelClass.CGBM: "#333333",      # darkslategray (RGB 51,51,51)
-    ModelClass.NGBOOST: "#1f77b4",   # tab:blue
-    ModelClass.CGLM: "#ff7f0e",      # tab:orange
-    ModelClass.INTERCEPT: "#2ca02c", # tab:green
+HexColor = Annotated[str, Field(pattern=r"^#[0-9a-fA-F]{6}$")]
+RGBTriple = tuple[
+    Annotated[int, Field(ge=0, le=255)],
+    Annotated[int, Field(ge=0, le=255)],
+    Annotated[int, Field(ge=0, le=255)],
+]
+
+DEFAULT_MODEL_COLORS: dict[ModelClass, HexColor] = {
+    ModelClass.GBM: "#B0B0B0",
+    ModelClass.CGBM: "#333333",
+    ModelClass.NGBOOST: "#1f77b4",
+    ModelClass.CGLM: "#ff7f0e",
+    ModelClass.INTERCEPT: "#2ca02c",
 }
 
-# Corresponding TikZ colour definitions (name → RGB triple).
-DEFAULT_TIKZ_COLORS: dict[str, tuple[int, int, int]] = {
+DEFAULT_TIKZ_COLORS: dict[ModelClass, RGBTriple] = {
     ModelClass.GBM: (176, 176, 176),
     ModelClass.CGBM: (51, 51, 51),
     ModelClass.NGBOOST: (31, 119, 180),
@@ -55,11 +63,11 @@ class ConcentrationCurvePlotConfig(BaseModel):
             ``test_data.csv``.
         mean_model_for_residuals: Which model's mean predictions to use when
             computing the squared-residual response for the variance
-            concentration curve.  Defaults to ``"gbm"``.
+            concentration curve.  Defaults to ``ModelClass.GBM``.
         n_points: Number of evenly spaced α-points on the [0, 1] grid.
-        model_colors: Matplotlib colour per model name.  Missing entries
+        model_colors: Matplotlib hex colour per model.  Missing entries
             fall back to ``DEFAULT_MODEL_COLORS`` or a built-in palette.
-        tikz_colors: TikZ RGB triple per model name.  Missing entries fall
+        tikz_colors: TikZ RGB triple per model.  Missing entries fall
             back to ``DEFAULT_TIKZ_COLORS``.
         output_dir: Directory where output files are written.  Defaults to
             the first dataset's ``results_dir``.
@@ -67,10 +75,10 @@ class ConcentrationCurvePlotConfig(BaseModel):
     """
 
     datasets: list[DatasetConfig]
-    models: list[str] | None = None
-    mean_model_for_residuals: str = ModelClass.GBM
+    models: list[ModelClass] | None = None
+    mean_model_for_residuals: ModelClass = ModelClass.GBM
     n_points: int = 100
-    model_colors: dict[str, str] | None = None
-    tikz_colors: dict[str, tuple[int, int, int]] | None = None
+    model_colors: dict[ModelClass, HexColor] | None = None
+    tikz_colors: dict[ModelClass, RGBTriple] | None = None
     output_dir: Path | None = None
     figsize: tuple[float, float] = (12.0, 5.0)

--- a/numerical_illustration/plots/concentration_config.py
+++ b/numerical_illustration/plots/concentration_config.py
@@ -1,0 +1,76 @@
+"""Configuration models for the concentration curve plot."""
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from numerical_illustration.schema.constants import ModelClass
+
+# Default model colours matching the paper's concentration_curves.tex.
+DEFAULT_MODEL_COLORS: dict[str, str] = {
+    ModelClass.GBM: "#B0B0B0",       # lightgray (RGB 176,176,176)
+    ModelClass.CGBM: "#333333",      # darkslategray (RGB 51,51,51)
+    ModelClass.NGBOOST: "#1f77b4",   # tab:blue
+    ModelClass.CGLM: "#ff7f0e",      # tab:orange
+    ModelClass.INTERCEPT: "#2ca02c", # tab:green
+}
+
+# Corresponding TikZ colour definitions (name → RGB triple).
+DEFAULT_TIKZ_COLORS: dict[str, tuple[int, int, int]] = {
+    ModelClass.GBM: (176, 176, 176),
+    ModelClass.CGBM: (51, 51, 51),
+    ModelClass.NGBOOST: (31, 119, 180),
+    ModelClass.CGLM: (255, 127, 14),
+    ModelClass.INTERCEPT: (44, 160, 44),
+}
+
+
+class DatasetConfig(BaseModel):
+    """Description of a single dataset (one row in the concentration curve grid).
+
+    Attributes:
+        results_dir: Path to a numerical illustration results directory
+            (must contain ``test_data.csv``).
+        distribution: Name of the parametric distribution used in the run,
+            e.g. ``"normal"``, ``"gamma"``, ``"neg_bin"``.
+        label: Human-readable label for this dataset, used in subplot titles
+            (e.g. ``"Number of claims"``, ``"Payment size"``).
+    """
+
+    results_dir: Path
+    distribution: str
+    label: str
+
+
+class ConcentrationCurvePlotConfig(BaseModel):
+    """Configuration for generating concentration curve plots.
+
+    The resulting figure has ``len(datasets)`` rows and 2 columns (expected
+    value / variance).
+
+    Attributes:
+        datasets: One entry per dataset row in the figure.
+        models: Subset of model names to include.  Defaults to all models
+            detected from the ``*_theta_0`` columns in the first dataset's
+            ``test_data.csv``.
+        mean_model_for_residuals: Which model's mean predictions to use when
+            computing the squared-residual response for the variance
+            concentration curve.  Defaults to ``"gbm"``.
+        n_points: Number of evenly spaced α-points on the [0, 1] grid.
+        model_colors: Matplotlib colour per model name.  Missing entries
+            fall back to ``DEFAULT_MODEL_COLORS`` or a built-in palette.
+        tikz_colors: TikZ RGB triple per model name.  Missing entries fall
+            back to ``DEFAULT_TIKZ_COLORS``.
+        output_dir: Directory where output files are written.  Defaults to
+            the first dataset's ``results_dir``.
+        figsize: Width and height of the matplotlib figure in inches.
+    """
+
+    datasets: list[DatasetConfig]
+    models: list[str] | None = None
+    mean_model_for_residuals: str = ModelClass.GBM
+    n_points: int = 100
+    model_colors: dict[str, str] | None = None
+    tikz_colors: dict[str, tuple[int, int, int]] | None = None
+    output_dir: Path | None = None
+    figsize: tuple[float, float] = (12.0, 5.0)

--- a/numerical_illustration/plots/concentration_curve_plot.py
+++ b/numerical_illustration/plots/concentration_curve_plot.py
@@ -26,8 +26,8 @@ Usage example::
         datasets=[
             DatasetConfig(
                 results_dir="data/results/20260531133858",
-                distribution="normal",
-                label="Simulated Normal",
+                distribution="gamma",
+                label="Simulated Gamma",
             ),
         ],
     )
@@ -47,19 +47,14 @@ from cyc_gbm.utils.distributions import initiate_distribution
 from .concentration_config import (
     DEFAULT_MODEL_COLORS,
     ConcentrationCurvePlotConfig,
-    DatasetConfig,
 )
 from .concentration_tikz_writer import write_concentration_tikz
 
-# Distributions whose support is [0, ∞) or a subset thereof.
-# Concentration curves are only meaningful for non-negative responses.
 _NON_NEGATIVE_DISTRIBUTIONS: set[str] = {
     "gamma",
     "neg_bin",
     "beta_prime",
-    "poisson",
     "inverse_gaussian",
-    "tweedie",
 }
 
 
@@ -73,10 +68,6 @@ def _check_distribution_support(distribution: str) -> None:
             f"values and would lead to meaningless concentration curves."
         )
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def _detect_models(data: pd.DataFrame) -> list[str]:
     """Return model names from columns named ``<model>_theta_0``."""
@@ -93,7 +84,6 @@ def _get_model_color(model: str, overrides: dict[str, str] | None) -> str:
         return overrides[model]
     if model in DEFAULT_MODEL_COLORS:
         return DEFAULT_MODEL_COLORS[model]
-    # Fallback: pick from the default matplotlib colour cycle.
     fallback_cycle = [
         "#d62728", "#9467bd", "#8c564b", "#e377c2",
         "#7f7f7f", "#bcbd22", "#17becf",
@@ -101,10 +91,6 @@ def _get_model_color(model: str, overrides: dict[str, str] | None) -> str:
     idx = hash(model) % len(fallback_cycle)
     return fallback_cycle[idx]
 
-
-# ---------------------------------------------------------------------------
-# Core computation
-# ---------------------------------------------------------------------------
 
 def _compute_concentration_curve(
     response: np.ndarray,
@@ -129,13 +115,10 @@ def _compute_concentration_curve(
     response_sorted = response[order]
     total = response_sorted.sum()
 
-    # Cumulative share of response.
     cumsum = np.concatenate([[0.0], np.cumsum(response_sorted)])
-    # Corresponding population fractions.
     n = len(response_sorted)
     fracs = np.arange(n + 1) / n
 
-    # Interpolate at the requested α-grid.
     alphas = np.linspace(0.0, 1.0, n_points + 1)
     cc = np.interp(alphas, fracs, cumsum / total if total != 0 else cumsum)
 
@@ -188,20 +171,14 @@ def _compute_variance_cc(
     y = test_data["y"].to_numpy()
     w = test_data["w"].to_numpy()
 
-    # Reference mean for centering (configurable model).
     ref_mean, _ = _model_moments(test_data, mean_model, mean_dist)
     squared_residuals = (y - w * ref_mean) ** 2
 
-    # This model's predicted variance for sorting.
     _, pred_var = _model_moments(test_data, model, dist)
     sort_values = w * pred_var
 
     return _compute_concentration_curve(squared_residuals, sort_values, n_points)
 
-
-# ---------------------------------------------------------------------------
-# Dat-file I/O
-# ---------------------------------------------------------------------------
 
 def _write_dat(path: Path, alphas: np.ndarray, values: np.ndarray) -> None:
     """Write ``alpha<space>value`` rows to *path*."""
@@ -209,10 +186,6 @@ def _write_dat(path: Path, alphas: np.ndarray, values: np.ndarray) -> None:
     lines = [f"{a} {v}" for a, v in zip(alphas, values)]
     path.write_text("\n".join(lines) + "\n")
 
-
-# ---------------------------------------------------------------------------
-# Matplotlib rendering
-# ---------------------------------------------------------------------------
 
 def _plot_cc_subplot(
     ax: plt.Axes,
@@ -222,7 +195,6 @@ def _plot_cc_subplot(
     show_legend: bool,
 ) -> None:
     """Render one concentration-curve panel."""
-    # Diagonal (identity line).
     ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=1)
 
     for model, (alphas, cc) in curves.items():
@@ -242,10 +214,6 @@ def _plot_cc_subplot(
         )
 
 
-# ---------------------------------------------------------------------------
-# Public entry point
-# ---------------------------------------------------------------------------
-
 def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> None:
     """Generate concentration curve plots from completed pipeline runs.
 
@@ -261,7 +229,6 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
     """
     datasets = config.datasets
 
-    # Validate that all distributions have non-negative support.
     for ds in datasets:
         _check_distribution_support(ds.distribution)
 
@@ -272,27 +239,21 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
     )
     dat_dir = output_dir / "dat"
 
-    # Resolve models from first dataset if not given.
     first_test = pd.read_csv(Path(datasets[0].results_dir) / "test_data.csv")
     models = (
         config.models if config.models is not None else _detect_models(first_test)
     )
 
-    # Resolve colours.
     resolved_colors: dict[str, str] = {
         m: _get_model_color(m, config.model_colors) for m in models
     }
 
-    # ---- Compute curves per dataset ----
-    # Structure: all_curves[dataset_idx]["mean"|"variance"][model] = (alphas, cc)
     all_curves: list[dict[str, dict[str, tuple[np.ndarray, np.ndarray]]]] = []
 
     for ds in datasets:
         test_data = pd.read_csv(Path(ds.results_dir) / "test_data.csv")
         dist = initiate_distribution(ds.distribution)
-
-        # Also need the mean-model's distribution for the residual centering.
-        mean_dist = dist  # same distribution, just different model columns
+        mean_dist = dist
 
         mean_curves: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         var_curves: dict[str, tuple[np.ndarray, np.ndarray]] = {}
@@ -310,8 +271,6 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
 
         all_curves.append({"mean": mean_curves, "variance": var_curves})
 
-    # ---- Export .dat files ----
-    # dat_paths[ds_idx][cc_type][model] = Path
     dat_paths: list[dict[str, dict[str, Path]]] = []
 
     for ds_idx, ds in enumerate(datasets):
@@ -326,7 +285,6 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
                 _write_dat(fpath, alphas, cc)
                 ds_dat[cc_type][model] = fpath
 
-        # Also write the diagonal.
         diag_alphas = np.linspace(0.0, 1.0, config.n_points + 1)
         for cc_type in ("mean", "variance"):
             diag_path = dat_dir / f"{label_slug}_{cc_type}_diagonal.dat"
@@ -335,7 +293,6 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
 
         dat_paths.append(ds_dat)
 
-    # ---- Matplotlib figure ----
     n_rows = len(datasets)
     n_cols = 2
     figw, figh = config.figsize
@@ -362,7 +319,6 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
     fig.savefig(png_path, dpi=150)
     plt.close(fig)
 
-    # ---- TikZ output ----
     tex_path = output_dir / "concentration_curve_plot.tex"
     write_concentration_tikz(
         path=tex_path,
@@ -372,10 +328,6 @@ def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> Non
         config=config,
     )
 
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     import argparse

--- a/numerical_illustration/plots/concentration_curve_plot.py
+++ b/numerical_illustration/plots/concentration_curve_plot.py
@@ -1,0 +1,395 @@
+"""Concentration curve plot for the numerical illustration pipeline.
+
+Produces:
+- A PNG figure (matplotlib)
+- Per-curve ``.dat`` data files (space-separated ``alpha value``)
+- A ``.tex`` file that assembles the data into a pgfplots groupplot,
+  matching the style of the paper's ``src/figures/concentration_curves.tex``.
+
+The concentration curve is defined following Eq. (3.1) in Denuit et al.:
+
+    CC(Y, μ̂(X); α) = E[Y · 1{μ̂(X) ≤ F⁻¹_μ̂(α)}] / E[Y],   α ∈ [0, 1].
+
+For variance assessment, Y is replaced with squared residuals centred on a
+configurable reference model's mean predictions, and the ordering is by the
+evaluated model's predicted variance.
+
+Usage example::
+
+    from numerical_illustration.plots import (
+        ConcentrationCurvePlotConfig,
+        create_concentration_curve_plot,
+    )
+    from numerical_illustration.plots.concentration_config import DatasetConfig
+
+    config = ConcentrationCurvePlotConfig(
+        datasets=[
+            DatasetConfig(
+                results_dir="data/results/20260531133858",
+                distribution="normal",
+                label="Simulated Normal",
+            ),
+        ],
+    )
+    create_concentration_curve_plot(config)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from cyc_gbm.utils.distributions import initiate_distribution
+
+from .concentration_config import (
+    DEFAULT_MODEL_COLORS,
+    ConcentrationCurvePlotConfig,
+    DatasetConfig,
+)
+from .concentration_tikz_writer import write_concentration_tikz
+
+# Distributions whose support is [0, ∞) or a subset thereof.
+# Concentration curves are only meaningful for non-negative responses.
+_NON_NEGATIVE_DISTRIBUTIONS: set[str] = {
+    "gamma",
+    "neg_bin",
+    "beta_prime",
+    "poisson",
+    "inverse_gaussian",
+    "tweedie",
+}
+
+
+def _check_distribution_support(distribution: str) -> None:
+    """Raise if *distribution* can produce negative values."""
+    if distribution not in _NON_NEGATIVE_DISTRIBUTIONS:
+        raise NotImplementedError(
+            f"Concentration curves are only implemented for distributions "
+            f"with non-negative support ({', '.join(sorted(_NON_NEGATIVE_DISTRIBUTIONS))}). "
+            f"Got distribution={distribution!r}, which can produce negative "
+            f"values and would lead to meaningless concentration curves."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _detect_models(data: pd.DataFrame) -> list[str]:
+    """Return model names from columns named ``<model>_theta_0``."""
+    return [
+        col.removesuffix("_theta_0")
+        for col in data.columns
+        if col.endswith("_theta_0") and col != "theta_0"
+    ]
+
+
+def _get_model_color(model: str, overrides: dict[str, str] | None) -> str:
+    """Resolve a matplotlib colour string for *model*."""
+    if overrides and model in overrides:
+        return overrides[model]
+    if model in DEFAULT_MODEL_COLORS:
+        return DEFAULT_MODEL_COLORS[model]
+    # Fallback: pick from the default matplotlib colour cycle.
+    fallback_cycle = [
+        "#d62728", "#9467bd", "#8c564b", "#e377c2",
+        "#7f7f7f", "#bcbd22", "#17becf",
+    ]
+    idx = hash(model) % len(fallback_cycle)
+    return fallback_cycle[idx]
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+def _compute_concentration_curve(
+    response: np.ndarray,
+    sort_values: np.ndarray,
+    n_points: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute an empirical concentration curve.
+
+    Args:
+        response: The variable being accumulated (y for mean CC,
+            squared residuals for variance CC).
+        sort_values: Values used to order observations (predicted mean
+            for mean CC, predicted variance for variance CC).
+        n_points: Number of evenly spaced α-points on [0, 1].
+
+    Returns:
+        ``(alphas, cc)`` where ``alphas`` has shape ``(n_points + 1,)``
+        ranging from 0 to 1 and ``cc`` is the corresponding concentration
+        curve values.
+    """
+    order = np.argsort(sort_values)
+    response_sorted = response[order]
+    total = response_sorted.sum()
+
+    # Cumulative share of response.
+    cumsum = np.concatenate([[0.0], np.cumsum(response_sorted)])
+    # Corresponding population fractions.
+    n = len(response_sorted)
+    fracs = np.arange(n + 1) / n
+
+    # Interpolate at the requested α-grid.
+    alphas = np.linspace(0.0, 1.0, n_points + 1)
+    cc = np.interp(alphas, fracs, cumsum / total if total != 0 else cumsum)
+
+    return alphas, cc
+
+
+def _model_moments(
+    data: pd.DataFrame,
+    model: str,
+    dist,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(pred_mean, pred_var)`` for *model* from *data*."""
+    n_dim = dist.n_dim if dist.n_dim is not None else sum(
+        1 for col in data.columns if col.startswith(f"{model}_theta_")
+    )
+    theta_cols = [f"{model}_theta_{j}" for j in range(n_dim)]
+    z = data[theta_cols].to_numpy().T
+    return dist.moment(z, k=1), dist.moment(z, k=2)
+
+
+def _compute_mean_cc(
+    test_data: pd.DataFrame,
+    model: str,
+    dist,
+    n_points: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Concentration curve based on mean predictions sorting, accumulating y."""
+    y = test_data["y"].to_numpy()
+    pred_mean, _ = _model_moments(test_data, model, dist)
+    return _compute_concentration_curve(y, pred_mean, n_points)
+
+
+def _compute_variance_cc(
+    test_data: pd.DataFrame,
+    model: str,
+    dist,
+    mean_model: str,
+    mean_dist,
+    n_points: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Concentration curve for variance predictions.
+
+    Squared residuals are centred on *mean_model*'s mean predictions.
+    Sorting is by the current *model*'s predicted variance.
+
+    When exposure weights ``w`` are present, the conditional mean is
+    ``w · μ̂(x)`` and the conditional variance is ``w · σ̂²(x)``.  The
+    squared residual for each observation is ``(y_i − w_i μ̂_ref_i)²``.
+    """
+    y = test_data["y"].to_numpy()
+    w = test_data["w"].to_numpy()
+
+    # Reference mean for centering (configurable model).
+    ref_mean, _ = _model_moments(test_data, mean_model, mean_dist)
+    squared_residuals = (y - w * ref_mean) ** 2
+
+    # This model's predicted variance for sorting.
+    _, pred_var = _model_moments(test_data, model, dist)
+    sort_values = w * pred_var
+
+    return _compute_concentration_curve(squared_residuals, sort_values, n_points)
+
+
+# ---------------------------------------------------------------------------
+# Dat-file I/O
+# ---------------------------------------------------------------------------
+
+def _write_dat(path: Path, alphas: np.ndarray, values: np.ndarray) -> None:
+    """Write ``alpha<space>value`` rows to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{a} {v}" for a, v in zip(alphas, values)]
+    path.write_text("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Matplotlib rendering
+# ---------------------------------------------------------------------------
+
+def _plot_cc_subplot(
+    ax: plt.Axes,
+    curves: dict[str, tuple[np.ndarray, np.ndarray]],
+    title: str,
+    model_colors: dict[str, str],
+    show_legend: bool,
+) -> None:
+    """Render one concentration-curve panel."""
+    # Diagonal (identity line).
+    ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=1)
+
+    for model, (alphas, cc) in curves.items():
+        color = model_colors.get(model, "black")
+        ax.plot(alphas, cc, color=color, linewidth=1.5, label=model.upper())
+
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_title(title)
+    ax.set_aspect("equal")
+
+    if show_legend:
+        ax.legend(
+            loc="upper left",
+            framealpha=0.8,
+            edgecolor="#cccccc",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def create_concentration_curve_plot(config: ConcentrationCurvePlotConfig) -> None:
+    """Generate concentration curve plots from completed pipeline runs.
+
+    Writes to *output_dir* (defaults to the first dataset's ``results_dir``):
+
+    - ``concentration_curve_plot.png``  — matplotlib figure
+    - ``dat/``                          — one ``.dat`` file per curve
+    - ``concentration_curve_plot.tex``  — pgfplots groupplot ready for
+      ``\\input``
+
+    Args:
+        config: Plot configuration.
+    """
+    datasets = config.datasets
+
+    # Validate that all distributions have non-negative support.
+    for ds in datasets:
+        _check_distribution_support(ds.distribution)
+
+    output_dir = (
+        Path(config.output_dir)
+        if config.output_dir
+        else Path(datasets[0].results_dir)
+    )
+    dat_dir = output_dir / "dat"
+
+    # Resolve models from first dataset if not given.
+    first_test = pd.read_csv(Path(datasets[0].results_dir) / "test_data.csv")
+    models = (
+        config.models if config.models is not None else _detect_models(first_test)
+    )
+
+    # Resolve colours.
+    resolved_colors: dict[str, str] = {
+        m: _get_model_color(m, config.model_colors) for m in models
+    }
+
+    # ---- Compute curves per dataset ----
+    # Structure: all_curves[dataset_idx]["mean"|"variance"][model] = (alphas, cc)
+    all_curves: list[dict[str, dict[str, tuple[np.ndarray, np.ndarray]]]] = []
+
+    for ds in datasets:
+        test_data = pd.read_csv(Path(ds.results_dir) / "test_data.csv")
+        dist = initiate_distribution(ds.distribution)
+
+        # Also need the mean-model's distribution for the residual centering.
+        mean_dist = dist  # same distribution, just different model columns
+
+        mean_curves: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        var_curves: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+        for model in models:
+            mean_curves[model] = _compute_mean_cc(
+                test_data, model, dist, config.n_points,
+            )
+            var_curves[model] = _compute_variance_cc(
+                test_data, model, dist,
+                mean_model=config.mean_model_for_residuals,
+                mean_dist=mean_dist,
+                n_points=config.n_points,
+            )
+
+        all_curves.append({"mean": mean_curves, "variance": var_curves})
+
+    # ---- Export .dat files ----
+    # dat_paths[ds_idx][cc_type][model] = Path
+    dat_paths: list[dict[str, dict[str, Path]]] = []
+
+    for ds_idx, ds in enumerate(datasets):
+        ds_dat: dict[str, dict[str, Path]] = {"mean": {}, "variance": {}}
+        label_slug = ds.label.lower().replace(" ", "_")
+
+        for cc_type in ("mean", "variance"):
+            for model in models:
+                alphas, cc = all_curves[ds_idx][cc_type][model]
+                fname = f"{label_slug}_{cc_type}_{model}.dat"
+                fpath = dat_dir / fname
+                _write_dat(fpath, alphas, cc)
+                ds_dat[cc_type][model] = fpath
+
+        # Also write the diagonal.
+        diag_alphas = np.linspace(0.0, 1.0, config.n_points + 1)
+        for cc_type in ("mean", "variance"):
+            diag_path = dat_dir / f"{label_slug}_{cc_type}_diagonal.dat"
+            _write_dat(diag_path, diag_alphas, diag_alphas)
+            ds_dat[cc_type]["__diagonal__"] = diag_path
+
+        dat_paths.append(ds_dat)
+
+    # ---- Matplotlib figure ----
+    n_rows = len(datasets)
+    n_cols = 2
+    figw, figh = config.figsize
+    fig, axes = plt.subplots(
+        n_rows, n_cols,
+        figsize=(figw, figh * n_rows / max(n_rows, 1)),
+        squeeze=False,
+    )
+
+    for ds_idx, ds in enumerate(datasets):
+        for col, cc_type in enumerate(("mean", "variance")):
+            cc_label = "expected value" if cc_type == "mean" else "variance"
+            title = f"{ds.label}, {cc_label}"
+            _plot_cc_subplot(
+                axes[ds_idx, col],
+                all_curves[ds_idx][cc_type],
+                title=title,
+                model_colors=resolved_colors,
+                show_legend=(ds_idx == 0 and col == 0),
+            )
+
+    fig.tight_layout()
+    png_path = output_dir / "concentration_curve_plot.png"
+    fig.savefig(png_path, dpi=150)
+    plt.close(fig)
+
+    # ---- TikZ output ----
+    tex_path = output_dir / "concentration_curve_plot.tex"
+    write_concentration_tikz(
+        path=tex_path,
+        datasets=datasets,
+        models=models,
+        dat_paths=dat_paths,
+        config=config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    import yaml
+
+    parser = argparse.ArgumentParser(
+        description="Generate concentration curve plots from numerical illustration runs."
+    )
+    parser.add_argument("--config", required=True, help="Path to YAML config file.")
+    args = parser.parse_args()
+
+    with open(args.config) as fh:
+        raw = yaml.safe_load(fh)
+
+    plot_config = ConcentrationCurvePlotConfig(**raw)
+    create_concentration_curve_plot(plot_config)

--- a/numerical_illustration/plots/concentration_tikz_writer.py
+++ b/numerical_illustration/plots/concentration_tikz_writer.py
@@ -1,0 +1,210 @@
+"""TikZ groupplot writer for concentration curve plots.
+
+Produces a ``.tex`` snippet that can be ``\\input``-ted directly into a LaTeX
+document, matching the style of the paper's
+``src/figures/concentration_curves.tex``.
+
+Each subplot contains:
+- One ``\\addplot`` line per model (with legend entry in the first panel).
+- A dashed black diagonal (identity line) with ``forget plot`` in subsequent
+  panels.
+- Fixed axes [0, 1] × [0, 1].
+
+Colours are resolved from the config or from ``DEFAULT_TIKZ_COLORS``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .concentration_config import (
+    DEFAULT_TIKZ_COLORS,
+    ConcentrationCurvePlotConfig,
+    DatasetConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_dat(path: Path) -> list[tuple[float, float]]:
+    """Read a ``.dat`` file and return ``[(alpha, value), ...]``."""
+    pairs: list[tuple[float, float]] = []
+    for line in path.read_text().strip().splitlines():
+        parts = line.split()
+        pairs.append((float(parts[0]), float(parts[1])))
+    return pairs
+
+
+def _inline_table(path: Path) -> str:
+    """Return an inline ``table {%...}`` block from a ``.dat`` file."""
+    pairs = _read_dat(path)
+    rows = "\n".join(f"{a} {v}" for a, v in pairs)
+    return f"table {{%\n{rows}\n}}"
+
+
+def _resolve_tikz_color_name(model: str) -> str:
+    """Return a LaTeX-safe colour name for *model*."""
+    return model.replace(" ", "").replace("_", "")
+
+
+def _resolve_tikz_color_rgb(
+    model: str,
+    overrides: dict[str, tuple[int, int, int]] | None,
+) -> tuple[int, int, int]:
+    """Resolve TikZ RGB triple for *model*."""
+    if overrides and model in overrides:
+        return overrides[model]
+    if model in DEFAULT_TIKZ_COLORS:
+        return DEFAULT_TIKZ_COLORS[model]
+    # Fallback palette.
+    fallback = [
+        (214, 39, 40), (148, 103, 189), (140, 86, 75),
+        (227, 119, 194), (127, 127, 127), (188, 189, 34), (23, 190, 207),
+    ]
+    return fallback[hash(model) % len(fallback)]
+
+
+# ---------------------------------------------------------------------------
+# Subplot body
+# ---------------------------------------------------------------------------
+
+def _subplot_body(
+    ds: DatasetConfig,
+    cc_type: str,
+    models: list[str],
+    series_paths: dict[str, Path],
+    is_first_panel: bool,
+    tikz_overrides: dict[str, tuple[int, int, int]] | None,
+) -> str:
+    """Return the tikz commands for a single ``\\nextgroupplot`` panel."""
+    cc_label = "expected value" if cc_type == "mean" else "variance"
+    title = f"{ds.label}, {cc_label}"
+
+    lines: list[str] = []
+
+    # -- groupplot options --
+    opts = [
+        "tick align=outside,",
+        "tick pos=left,",
+        f"title={{{title}}},",
+        "x grid style={darkgray176},",
+        "xmin=0, xmax=1,",
+        "xtick style={color=black},",
+        "y grid style={darkgray176},",
+        "ymin=0, ymax=1,",
+        "ytick style={color=black}",
+    ]
+
+    if is_first_panel:
+        legend_opts = [
+            "legend cell align={left},",
+            "legend style={",
+            "  fill opacity=0.8,",
+            "  draw opacity=1,",
+            "  text opacity=1,",
+            "  at={(0.03,0.97)},",
+            "  anchor=north west,",
+            "  draw=lightgray204",
+            "},",
+        ]
+        opts = legend_opts + opts
+
+    lines.append("\\nextgroupplot[")
+    lines.extend(opts)
+    lines.append("]")
+
+    # -- model curves --
+    for m_idx, model in enumerate(models):
+        color_name = _resolve_tikz_color_name(model)
+        table = _inline_table(series_paths[model])
+
+        if is_first_panel:
+            lines.append(f"\\addplot [semithick, {color_name}]")
+            lines.append(f"{table};")
+            lines.append(f"\\addlegendentry{{{model.upper()}}}")
+        else:
+            lines.append(f"\\addplot [semithick, {color_name}]")
+            lines.append(f"{table};")
+
+    # -- diagonal --
+    diag_table = _inline_table(series_paths["__diagonal__"])
+    forget = ", forget plot" if is_first_panel else ""
+    lines.append(f"\\addplot [semithick, black, dashed{forget}]")
+    lines.append(f"{diag_table};")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def write_concentration_tikz(
+    path: Path,
+    datasets: list[DatasetConfig],
+    models: list[str],
+    dat_paths: list[dict[str, dict[str, Path]]],
+    config: ConcentrationCurvePlotConfig,
+) -> None:
+    """Write a pgfplots groupplot ``.tex`` file to *path*.
+
+    Args:
+        path: Destination ``.tex`` file.
+        datasets: One entry per row in the figure.
+        models: Ordered list of model names.
+        dat_paths: ``dat_paths[ds_idx][cc_type][model_or_diagonal]`` → Path.
+        config: Full plot configuration (used for colour overrides).
+    """
+    n_rows = len(datasets)
+    n_cols = 2
+
+    # ---- Colour definitions ----
+    color_defs: list[str] = []
+    # Always define the two "structural" colours used for grid/legend frame.
+    color_defs.append("\\definecolor{darkgray176}{RGB}{176,176,176}")
+    color_defs.append("\\definecolor{lightgray204}{RGB}{204,204,204}")
+
+    for model in models:
+        cname = _resolve_tikz_color_name(model)
+        r, g, b = _resolve_tikz_color_rgb(model, config.tikz_colors)
+        color_defs.append(f"\\definecolor{{{cname}}}{{RGB}}{{{r},{g},{b}}}")
+
+    # ---- Subplots ----
+    subplots: list[str] = []
+    is_first = True
+
+    for ds_idx, ds in enumerate(datasets):
+        for cc_type in ("mean", "variance"):
+            subplots.append(
+                _subplot_body(
+                    ds=ds,
+                    cc_type=cc_type,
+                    models=models,
+                    series_paths=dat_paths[ds_idx][cc_type],
+                    is_first_panel=is_first,
+                    tikz_overrides=config.tikz_colors,
+                )
+            )
+            is_first = False
+
+    body = "\n\n".join(subplots)
+    defs = "\n".join(color_defs)
+
+    tex = (
+        "% Generated by numerical_illustration/plots/concentration_tikz_writer.py\n"
+        "\\begin{tikzpicture}[scale = 0.75]\n"
+        "\n"
+        f"{defs}\n"
+        "\n"
+        f"\\begin{{groupplot}}[group style={{group size={n_cols} by {n_rows}, "
+        "vertical sep=1.5cm}]\n"
+        f"{body}\n"
+        "\\end{groupplot}\n"
+        "\n"
+        "\\end{tikzpicture}\n"
+    )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(tex)

--- a/numerical_illustration/plots/concentration_tikz_writer.py
+++ b/numerical_illustration/plots/concentration_tikz_writer.py
@@ -24,10 +24,6 @@ from .concentration_config import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 def _read_dat(path: Path) -> list[tuple[float, float]]:
     """Read a ``.dat`` file and return ``[(alpha, value), ...]``."""
     pairs: list[tuple[float, float]] = []
@@ -58,17 +54,12 @@ def _resolve_tikz_color_rgb(
         return overrides[model]
     if model in DEFAULT_TIKZ_COLORS:
         return DEFAULT_TIKZ_COLORS[model]
-    # Fallback palette.
     fallback = [
         (214, 39, 40), (148, 103, 189), (140, 86, 75),
         (227, 119, 194), (127, 127, 127), (188, 189, 34), (23, 190, 207),
     ]
     return fallback[hash(model) % len(fallback)]
 
-
-# ---------------------------------------------------------------------------
-# Subplot body
-# ---------------------------------------------------------------------------
 
 def _subplot_body(
     ds: DatasetConfig,
@@ -84,7 +75,6 @@ def _subplot_body(
 
     lines: list[str] = []
 
-    # -- groupplot options --
     opts = [
         "tick align=outside,",
         "tick pos=left,",
@@ -115,8 +105,7 @@ def _subplot_body(
     lines.extend(opts)
     lines.append("]")
 
-    # -- model curves --
-    for m_idx, model in enumerate(models):
+    for model in models:
         color_name = _resolve_tikz_color_name(model)
         table = _inline_table(series_paths[model])
 
@@ -128,7 +117,6 @@ def _subplot_body(
             lines.append(f"\\addplot [semithick, {color_name}]")
             lines.append(f"{table};")
 
-    # -- diagonal --
     diag_table = _inline_table(series_paths["__diagonal__"])
     forget = ", forget plot" if is_first_panel else ""
     lines.append(f"\\addplot [semithick, black, dashed{forget}]")
@@ -136,10 +124,6 @@ def _subplot_body(
 
     return "\n".join(lines)
 
-
-# ---------------------------------------------------------------------------
-# Public entry point
-# ---------------------------------------------------------------------------
 
 def write_concentration_tikz(
     path: Path,
@@ -160,9 +144,7 @@ def write_concentration_tikz(
     n_rows = len(datasets)
     n_cols = 2
 
-    # ---- Colour definitions ----
     color_defs: list[str] = []
-    # Always define the two "structural" colours used for grid/legend frame.
     color_defs.append("\\definecolor{darkgray176}{RGB}{176,176,176}")
     color_defs.append("\\definecolor{lightgray204}{RGB}{204,204,204}")
 
@@ -171,7 +153,6 @@ def write_concentration_tikz(
         r, g, b = _resolve_tikz_color_rgb(model, config.tikz_colors)
         color_defs.append(f"\\definecolor{{{cname}}}{{RGB}}{{{r},{g},{b}}}")
 
-    # ---- Subplots ----
     subplots: list[str] = []
     is_first = True
 


### PR DESCRIPTION
## Summary

Adds a concentration curve plot tool to `numerical_illustration/plots`, implementing the concentration curves described in the paper (Eq. 3.1, Denuit et al.).

- **Mean CC:** sorts test observations by predicted mean, accumulates response — measures how well the model discriminates risk levels.
- **Variance CC:** sorts by predicted variance, accumulates squared residuals centred on a configurable reference model's mean predictions — measures variance discrimination.

## New files

| File | Purpose |
|------|---------|
| `concentration_config.py` | `DatasetConfig` + `ConcentrationCurvePlotConfig` (Pydantic), default colour palettes keyed by `ModelClass` StrEnum |
| `concentration_curve_plot.py` | Core CC computation, `.dat` export, matplotlib rendering, YAML CLI |
| `concentration_tikz_writer.py` | Self-contained `.tex` pgfplots groupplot output matching the paper's style |

## Design

- **Configurable n×2 grid** — `datasets` list gives one row per dataset (mean CC left, variance CC right), matching the paper's layout
- **Configurable `mean_model_for_residuals`** — which model's μ̂ centres the squared residuals for variance CC (defaults to `ModelClass.GBM`)
- **`NotImplementedError`** for distributions with negative support (e.g. Normal) — concentration curves are meaningless there
- **Exposure weight support** — handles non-unit `w` in the CC formula
- **Configurable colours** with paper-matching defaults (`lightgray` for GBM, `darkslategray` for CGBM)
- **Same pipeline pattern** as `binned_response_plot`: config → read CSV → compute → `.dat` → `.png` → `.tex`
