### PR TITLE
[Feature] Add shape-rate parameterization for gamma distribution

### DIFF
--- a/cyc_gbm/cyc_gbm.py
+++ b/cyc_gbm/cyc_gbm.py
@@ -34,6 +34,7 @@ class CyclicalGradientBooster:
         min_samples_leaf: int | list[int] = 1,
         max_depth: int | list[int] = 3,
         feature_selection: list[list[str | int]] | None = None,
+        parameterization: str = "mean-dispersion",
     ):
         """
         Initialize a CyclicalGradientBooster object.
@@ -45,9 +46,12 @@ class CyclicalGradientBooster:
         :param min_samples_leaf: Minimum number of samples required at a leaf node. Dimension-wise or global for all parameter dimensions.
         :param max_depth: Maximum depths of each decision tree. Dimension-wise or global for all parameter dimensions.
         :param feature_selection: Features to use for each parameter dimension. If None, all feature_selection are used for all parameter dimensions.
+        :param parameterization: The parameterization to use for the distribution. Default is "mean-dispersion". See `initiate_distribution` for supported alternatives.
         """
         if isinstance(distribution, str):
-            self.distribution = initiate_distribution(distribution=distribution)
+            self.distribution = initiate_distribution(
+                distribution=distribution, parameterization=parameterization
+            )
         else:
             self.distribution = distribution
         self.n_dim = self.distribution.n_dim

--- a/cyc_gbm/utils/distributions.py
+++ b/cyc_gbm/utils/distributions.py
@@ -521,6 +521,71 @@ class GammaDistribution(Distribution):
 
 
 @inherit_docstrings
+class GammaShapeRateDistribution(Distribution):
+    def __init__(
+        self,
+    ) -> None:
+        """
+        Initialize a gamma distribution object with shape-rate parameterization.
+
+        Parameterization: z[0] = log(alpha), z[1] = log(beta), where E[Y] = w*alpha/beta, Var(Y) = w*alpha/beta^2
+        """
+        super().__init__(n_dim=2)
+
+    def loss(
+        self, y: np.ndarray, z: np.ndarray, w: np.ndarray | float = 1.0
+    ) -> np.ndarray:
+        return (
+            loggamma(w * np.exp(z[0]))
+            - w * np.exp(z[0]) * z[1]
+            + np.exp(z[1]) * y
+            - (w * np.exp(z[0]) - 1) * np.log(y)
+        )
+
+    def grad(
+        self, y: np.ndarray, z: np.ndarray, j: int, w: np.ndarray | float = 1.0
+    ) -> np.ndarray:
+        if j == 0:
+            return (
+                w
+                * np.exp(z[0])
+                * (polygamma(0, w * np.exp(z[0])) - z[1] - np.log(y))
+            )
+        elif j == 1:
+            return np.exp(z[1]) * y - w * np.exp(z[0])
+
+    def mme(self, y: np.ndarray, w: np.ndarray | float = 1.0) -> np.ndarray:
+        if isinstance(w, float):
+            w = np.array([w] * len(y))
+        mean = y.sum() / w.sum()
+        var = sum((y - y.mean()) ** 2) / w.sum()
+        alpha = mean**2 / var
+        beta = mean / var
+        return np.array([np.log(alpha), np.log(beta)])
+
+    def simulate(
+        self,
+        z: np.ndarray,
+        w: np.ndarray | float = 1.0,
+        random_state: int | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        if rng is None:
+            rng = np.random.default_rng(seed=random_state)
+        shape = w * np.exp(z[0])
+        scale = np.exp(-z[1])
+        return rng.gamma(shape=shape, scale=scale)
+
+    def moment(
+        self, z: np.ndarray, k: int, w: np.ndarray | float = 1.0
+    ) -> np.ndarray:
+        if k == 1:
+            return w * np.exp(z[0] - z[1])
+        elif k == 2:
+            return w * np.exp(z[0] - 2 * z[1])
+
+
+@inherit_docstrings
 class BetaPrimeDistribution(Distribution):
     def __init__(
         self,
@@ -680,6 +745,7 @@ def initiate_distribution(
     ] | None = None,
     moment: Callable[[np.ndarray, int, np.ndarray | float], np.ndarray] | None = None,
     n_dim: int = 2,
+    parameterization: str = "mean-dispersion",
 ) -> Distribution:
     """
     Returns a probability distribution object based on the distribution name.
@@ -691,9 +757,21 @@ def initiate_distribution(
     :param simulate: A function that simulates data from the distribution. Only used if dist == "custom".
     :param moment: A function that computes the kth moment of the distribution. Only used if dist == "custom".
     :param d: The dimension of the distribution.
+    :param parameterization: The parameterization to use. Default is "mean-dispersion".
+        Alternative parameterizations are only supported for certain distributions
+        (e.g. "shape-rate" for gamma).
     :return: A probability distribution object based on the distribution name.
-    :raises UnknownDistribution: If the input distribution name is not recognized.
+    :raises ValueError: If the input distribution name is not recognized, or if
+        the parameterization is not supported for the given distribution.
     """
+    if parameterization != "mean-dispersion":
+        if distribution != "gamma" or parameterization != "shape-rate":
+            raise ValueError(
+                f'Parameterization "{parameterization}" is not supported for '
+                f'distribution "{distribution}". Only the gamma distribution '
+                f'supports an alternative parameterization ("shape-rate").'
+            )
+        return GammaShapeRateDistribution()
     if distribution == "normal":
         if n_dim == 2:
             return NormalDistribution()

--- a/tests/test_cyc_gbm.py
+++ b/tests/test_cyc_gbm.py
@@ -34,6 +34,7 @@ class CyclicalGradientBoosterTestCase(unittest.TestCase):
         expected_loss: float,
         n_dim: int,
         use_weights: bool = False,
+        parameterization: str = "mean-dispersion",
     ):
         """
         Test method for the CycGBM` class on a dataset where the target variable
@@ -43,9 +44,10 @@ class CyclicalGradientBoosterTestCase(unittest.TestCase):
         :param expected_loss: The expected loss of the CycGBM model.
         :param n_dim: The number of dimensions to use
         :param use_weights: Whether to use weights in the fit method.
+        :param parameterization: The parameterization to use. Default is "mean-dispersion".
         """
         distribution = initiate_distribution(
-            distribution=distribution_name, n_dim=n_dim
+            distribution=distribution_name, n_dim=n_dim, parameterization=parameterization
         )
         z = self.z[:n_dim]
         w = self.w if use_weights else np.ones(self.X.shape[0])
@@ -89,6 +91,29 @@ class CyclicalGradientBoosterTestCase(unittest.TestCase):
             n_dim=2,
             use_weights=True,
         )
+
+    def test_gamma_shape_rate_distribution(self):
+        self._test_distribution(
+            distribution_name="gamma",
+            expected_loss=1.8979316934619745,
+            n_dim=2,
+            parameterization="shape-rate",
+        )
+
+    def test_gamma_shape_rate_distribution_weighted(self):
+        self._test_distribution(
+            distribution_name="gamma",
+            expected_loss=1.9064661460574803,
+            n_dim=2,
+            use_weights=True,
+            parameterization="shape-rate",
+        )
+
+    def test_invalid_parameterization(self):
+        with self.assertRaises(ValueError):
+            initiate_distribution(
+                distribution="normal", parameterization="shape-rate"
+            )
 
     def test_beta_prime(self):
         self._test_distribution(


### PR DESCRIPTION
## Summary

- Adds `GammaShapeRateDistribution` class with parameterization `z[0] = log(α)`, `z[1] = log(β)`, where `E[Y] = w·α/β` and `Var(Y) = w·α/β²`.
- Extends `initiate_distribution` factory with a `parameterization` keyword (default `"mean-dispersion"`, also accepts `"shape-rate"` for gamma). Raises `ValueError` for unsupported distribution/parameterization combinations.
- Propagates the `parameterization` kwarg through `CyclicalGradientBooster.__init__`.

## Tests

- Added `test_gamma_shape_rate_distribution` (unweighted) and `test_gamma_shape_rate_distribution_weighted`.
- Added `test_invalid_parameterization` to verify `ValueError` for unsupported combinations.
- All 15 tests pass.