### PR TITLE
fix: sklearn categorical bitset attribute + predict n_dim inference

### DIFF
--- a/cyc_gbm/boosting_tree.py
+++ b/cyc_gbm/boosting_tree.py
@@ -160,7 +160,7 @@ class BoostingTree:
             # This is a leaf
             return
         if feature in self.categorical_features:
-            bitset = tree.left_cat_bitset[node_index]
+            bitset = tree._left_cat_bitset[node_index]
             index_left = self._split_categorical(X, feature, bitset)
         else:
             threshold = tree.threshold[node_index]

--- a/numerical_illustration/tasks/predict.py
+++ b/numerical_illustration/tasks/predict.py
@@ -27,7 +27,11 @@ def predict(
         model_name: models[model_name].predict(X_test) for model_name in models
     }
 
-    n_dim = len([col for col in data.columns if col.startswith("theta")])
+    # Infer n_dim from the first model's prediction shape rather than
+    # relying on theta_* columns which only exist for simulated data.
+    first_pred = next(iter(predictions.values()))
+    n_dim = first_pred.shape[0]
+
     for model_name in models:
         for j in range(n_dim):
             data[f"{model_name}_theta_{j}"] = predictions[model_name][j]


### PR DESCRIPTION
## Summary
- Rename `tree.left_cat_bitset` → `tree._left_cat_bitset` to match the current scikit-learn categorical feature branch API
- Infer `n_dim` in `predict.py` from model prediction shape instead of counting `theta_*` columns (which only exist for simulated data)

**Stack:** 1/4 → `main`