### PR TITLE
feat: expose min_samples_leaf in GBM/CGBM YAML configs

### DIFF
--- a/numerical_illustration/schema/models.py
+++ b/numerical_illustration/schema/models.py
@@ -18,12 +18,14 @@ class GradientBoostingMachineConfig(BaseModel):
         n_estimators: Maximum number of boosting iterations.
         max_depth: Maximum depth of each decision tree.
         learning_rate: Shrinkage applied to each tree.
+        min_samples_leaf: Minimum samples required at a leaf node.
     """
 
     model_class: Literal[ModelClass.GBM]
     n_estimators: int = 600
     max_depth: int = 3
     learning_rate: float = 0.05
+    min_samples_leaf: int = 1
 
     def n_estimators_as_list(self, n_dim: int) -> list[int]:
         """Return n_estimators as a per-dimension list for CyclicalGradientBooster.
@@ -45,12 +47,14 @@ class CyclicalGradientBoostingMachineConfig(BaseModel):
         n_estimators: Maximum boosting iterations per parameter dimension.
         max_depth: Maximum depth of each decision tree.
         learning_rate: Shrinkage applied to each tree (scalar or per-dimension).
+        min_samples_leaf: Minimum samples required at a leaf node.
     """
 
     model_class: Literal[ModelClass.CGBM]
     n_estimators: list[int] = Field(default_factory=lambda: [600, 600])
     max_depth: int = 3
     learning_rate: float | list[float] = 0.05
+    min_samples_leaf: int = 1
 
 
 class NaturalGradientBoostingMachineConfig(BaseModel):

--- a/numerical_illustration/tasks/fit_models.py
+++ b/numerical_illustration/tasks/fit_models.py
@@ -87,6 +87,7 @@ def _build_and_fit(
             n_estimators=n_estimators[mc],
             learning_rate=model_config.learning_rate,
             max_depth=model_config.max_depth,
+            min_samples_leaf=model_config.min_samples_leaf,
         )
 
     elif isinstance(model_config, GradientBoostingMachineConfig):
@@ -95,6 +96,7 @@ def _build_and_fit(
             n_estimators=n_estimators[mc],
             learning_rate=model_config.learning_rate,
             max_depth=model_config.max_depth,
+            min_samples_leaf=model_config.min_samples_leaf,
         )
 
     elif isinstance(model_config, NaturalGradientBoostingMachineConfig):

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -48,6 +48,7 @@ def tune_models(
                 distribution=distribution,
                 learning_rate=mc.learning_rate,
                 max_depth=mc.max_depth,
+                min_samples_leaf=mc.min_samples_leaf,
             )
 
             if isinstance(mc, CyclicalGradientBoostingMachineConfig):


### PR DESCRIPTION
## Summary
- Add `min_samples_leaf` parameter (default 1) to `GradientBoostingMachineConfig` and `CyclicalGradientBoostingMachineConfig`
- Wire it through to `CyclicalGradientBooster` in both `fit_models.py` and `tune_models.py`

Needed for real data examples where the paper uses `min_samples_leaf: 20`.

**Stack:** 2/4 → `fix/pipeline-bugfixes`