### PR TITLE
feat: categorical feature support throughout the numerical illustration pipeline

### DIFF
--- a/cyc_gbm/utils/tuning.py
+++ b/cyc_gbm/utils/tuning.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+import pandas as pd
 
 from cyc_gbm import CyclicalGradientBooster
 from cyc_gbm.utils.utils import calculate_progress
@@ -76,7 +77,7 @@ def tune_n_estimators(
 
 
 def _fold_split(
-    X: "np.ndarray | pd.DataFrame",
+    X: np.ndarray | pd.DataFrame,
     y: np.ndarray,
     w: float | np.ndarray,
     n_splits: int,
@@ -91,36 +92,57 @@ def _fold_split(
     :return A dictionary containing the folds as tuples in the order
         (X_train, y_train, w_train, X_valid, y_valid, w_valid).
     """
-    import pandas as pd
-
-    if isinstance(w, float):
-        w = np.ones(len(y)) * w
+    y = np.asarray(y)
+    w = np.asarray(w) if not isinstance(w, float) else np.ones(len(y)) * w
     idx = rng.permutation(X.shape[0])
     idx_folds = np.array_split(idx, n_splits)
-    is_df = isinstance(X, pd.DataFrame)
-    folds = {}
-    for i in range(n_splits):
-        idx_test = idx_folds[i]
-        idx_train = np.concatenate(idx_folds[:i] + idx_folds[i + 1 :])
-        if is_df:
-            folds[i] = (
-                X.iloc[idx_train].reset_index(drop=True),
-                y[idx_train],
-                w[idx_train],
-                X.iloc[idx_test].reset_index(drop=True),
-                y[idx_test],
-                w[idx_test],
-            )
-        else:
-            folds[i] = (
-                X[idx_train],
-                y[idx_train],
-                w[idx_train],
-                X[idx_test],
-                y[idx_test],
-                w[idx_test],
-            )
-    return folds
+    split_fn = _split_dataframe if isinstance(X, pd.DataFrame) else _split_array
+    return {
+        i: split_fn(
+            X=X,
+            y=y,
+            w=w,
+            idx_train=np.concatenate(idx_folds[:i] + idx_folds[i + 1 :]),
+            idx_test=idx_folds[i],
+        )
+        for i in range(n_splits)
+    }
+
+
+def _split_dataframe(
+    X: pd.DataFrame,
+    y: np.ndarray,
+    w: np.ndarray,
+    idx_train: np.ndarray,
+    idx_test: np.ndarray,
+) -> tuple:
+    """Create a single fold tuple from a DataFrame."""
+    return (
+        X.iloc[idx_train].reset_index(drop=True),
+        y[idx_train],
+        w[idx_train],
+        X.iloc[idx_test].reset_index(drop=True),
+        y[idx_test],
+        w[idx_test],
+    )
+
+
+def _split_array(
+    X: np.ndarray,
+    y: np.ndarray,
+    w: np.ndarray,
+    idx_train: np.ndarray,
+    idx_test: np.ndarray,
+) -> tuple:
+    """Create a single fold tuple from a numpy array."""
+    return (
+        X[idx_train],
+        y[idx_train],
+        w[idx_train],
+        X[idx_test],
+        y[idx_test],
+        w[idx_test],
+    )
 
 
 def _evaluate_fold(

--- a/cyc_gbm/utils/tuning.py
+++ b/cyc_gbm/utils/tuning.py
@@ -76,38 +76,50 @@ def tune_n_estimators(
 
 
 def _fold_split(
-    X: np.ndarray,
+    X: "np.ndarray | pd.DataFrame",
     y: np.ndarray,
     w: float | np.ndarray,
     n_splits: int,
     rng: np.random.Generator,
-) -> dict[
-    int, tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-]:
+) -> dict[int, tuple]:
     """Split data into k folds.
 
     :param X: The input data matrix of shape (n_samples, n_features).
+        May be a numpy array or a pandas DataFrame.
     :param n_splits: The number of folds to use for k-fold cross-validation.
     :param rng: The random number generator.
     :return A dictionary containing the folds as tuples in the order
         (X_train, y_train, w_train, X_valid, y_valid, w_valid).
     """
+    import pandas as pd
+
     if isinstance(w, float):
         w = np.ones(len(y)) * w
     idx = rng.permutation(X.shape[0])
     idx_folds = np.array_split(idx, n_splits)
+    is_df = isinstance(X, pd.DataFrame)
     folds = {}
     for i in range(n_splits):
         idx_test = idx_folds[i]
         idx_train = np.concatenate(idx_folds[:i] + idx_folds[i + 1 :])
-        folds[i] = (
-            X[idx_train],
-            y[idx_train],
-            w[idx_train],
-            X[idx_test],
-            y[idx_test],
-            w[idx_test],
-        )
+        if is_df:
+            folds[i] = (
+                X.iloc[idx_train].reset_index(drop=True),
+                y[idx_train],
+                w[idx_train],
+                X.iloc[idx_test].reset_index(drop=True),
+                y[idx_test],
+                w[idx_test],
+            )
+        else:
+            folds[i] = (
+                X[idx_train],
+                y[idx_train],
+                w[idx_train],
+                X[idx_test],
+                y[idx_test],
+                w[idx_test],
+            )
     return folds
 
 

--- a/numerical_illustration/schema/data.py
+++ b/numerical_illustration/schema/data.py
@@ -58,8 +58,12 @@ class LocalDataConfig(DataConfig):
         file_path: Path to the CSV file.
         random_seed: Seed for the random number generator used in
             train/test splitting.
+        categorical_features: Column names to cast to
+            ``pd.CategoricalDtype`` after loading.  These are then
+            automatically picked up by ``CyclicalGradientBooster``.
     """
 
     data_source: Literal[DataSource.FILE]
     file_path: Path
     random_seed: int = 42
+    categorical_features: list[str] = []

--- a/numerical_illustration/tasks/baseline_models/cyc_glm.py
+++ b/numerical_illustration/tasks/baseline_models/cyc_glm.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pandas as pd
 from scipy.optimize import minimize
+from sklearn.preprocessing import OneHotEncoder
 
 from cyc_gbm.utils.distributions import Distribution
 
@@ -25,11 +27,15 @@ class CyclicGeneralizedLinearModel:
         self.eps = eps
         self.beta = None
         self.z0 = None
+        self._encoder: OneHotEncoder | None = None
 
-    def fit(self, X: np.ndarray, y: np.ndarray, w: np.ndarray) -> None:
+    def fit(self, X: np.ndarray | pd.DataFrame, y: np.ndarray, w: np.ndarray) -> None:
         """
         Fit the model.
         """
+        if isinstance(X, pd.DataFrame):
+            self._encoder = self._fit_encoder(X)
+            X = self._encode(X)
         n = len(y)
         z = np.zeros((self.d, n))
         self.z0 = minimize(
@@ -58,11 +64,41 @@ class CyclicGeneralizedLinearModel:
 
         self.beta = beta[i]
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
+    def predict(self, X: np.ndarray | pd.DataFrame) -> np.ndarray:
         """
         Predict the response for the given input data.
         """
+        if isinstance(X, pd.DataFrame):
+            X = self._encode(X)
         z = np.zeros((self.d, X.shape[0]))
         for j in range(self.d):
             z[j] = self.z0[j] + self.beta[j] @ X.T
         return z
+
+    @staticmethod
+    def _fit_encoder(X: pd.DataFrame) -> OneHotEncoder | None:
+        """Fit a one-hot encoder for categorical columns in *X*."""
+        cat_cols = [
+            c for c in X.columns
+            if isinstance(X[c].dtype, pd.CategoricalDtype)
+        ]
+        if not cat_cols:
+            return None
+        encoder = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
+        encoder.fit(X[cat_cols])
+        encoder._cat_cols = cat_cols  # type: ignore[attr-defined]
+        return encoder
+
+    def _encode(self, X: pd.DataFrame) -> np.ndarray:
+        """Convert a DataFrame to a numeric numpy array.
+
+        Categorical columns are one-hot encoded; numeric columns are
+        passed through.
+        """
+        if self._encoder is None:
+            return X.to_numpy(dtype=float, na_value=0.0)
+        cat_cols = self._encoder._cat_cols  # type: ignore[attr-defined]
+        num_cols = [c for c in X.columns if c not in cat_cols]
+        encoded = self._encoder.transform(X[cat_cols])
+        numeric = X[num_cols].to_numpy(dtype=float, na_value=0.0)
+        return np.hstack([numeric, encoded])

--- a/numerical_illustration/tasks/baseline_models/ngboost_model.py
+++ b/numerical_illustration/tasks/baseline_models/ngboost_model.py
@@ -1,9 +1,11 @@
 import logging
 
 import numpy as np
+import pandas as pd
 from ngboost import NGBRegressor
 from ngboost.distns import Normal
 from ngboost.scores import MLE
+from sklearn.preprocessing import OneHotEncoder
 from sklearn.tree import DecisionTreeRegressor
 
 from cyc_gbm.utils.distributions import Distribution, NormalDistribution
@@ -49,13 +51,17 @@ class NGBoostModel:
         self.max_depth = max_depth
         self.random_state = random_state
         self._model = None
+        self._encoder: OneHotEncoder | None = None
 
     def fit(
         self,
-        X: np.ndarray,
+        X: np.ndarray | pd.DataFrame,
         y: np.ndarray,
         w: np.ndarray | float = 1,
     ) -> None:
+        if isinstance(X, pd.DataFrame):
+            self._encoder = self._fit_encoder(X)
+            X = self._encode(X)
         self._model = NGBRegressor(
             Dist=Normal,
             Score=MLE,
@@ -70,11 +76,37 @@ class NGBoostModel:
         else:
             self._model.fit(X, y)
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
+    def predict(self, X: np.ndarray | pd.DataFrame) -> np.ndarray:
+        if isinstance(X, pd.DataFrame):
+            X = self._encode(X)
         dist = self._model.pred_dist(X)
         mu = dist.loc
         log_sigma = np.log(dist.scale)
         return np.stack([mu, log_sigma])
+
+    @staticmethod
+    def _fit_encoder(X: pd.DataFrame) -> OneHotEncoder | None:
+        """Fit a one-hot encoder for categorical columns in *X*."""
+        cat_cols = [
+            c for c in X.columns
+            if isinstance(X[c].dtype, pd.CategoricalDtype)
+        ]
+        if not cat_cols:
+            return None
+        encoder = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
+        encoder.fit(X[cat_cols])
+        encoder._cat_cols = cat_cols  # type: ignore[attr-defined]
+        return encoder
+
+    def _encode(self, X: pd.DataFrame) -> np.ndarray:
+        """Convert DataFrame to numeric numpy, one-hot encoding categoricals."""
+        if self._encoder is None:
+            return X.to_numpy(dtype=float, na_value=0.0)
+        cat_cols = self._encoder._cat_cols  # type: ignore[attr-defined]
+        num_cols = [c for c in X.columns if c not in cat_cols]
+        encoded = self._encoder.transform(X[cat_cols])
+        numeric = X[num_cols].to_numpy(dtype=float, na_value=0.0)
+        return np.hstack([numeric, encoded])
 
     def compute_feature_importances(self, j: str | int | None = None) -> np.ndarray:
         """Compute feature importances from the fitted NGBoost model.

--- a/numerical_illustration/tasks/load_input_data.py
+++ b/numerical_illustration/tasks/load_input_data.py
@@ -71,11 +71,19 @@ def _load_data_from_file(data_config: DataConfig) -> pd.DataFrame:
     if "w" not in data.columns:
         data["w"] = 1
 
-    # Cast configured columns to pd.CategoricalDtype so that
-    # CyclicalGradientBooster can detect them automatically.
     if hasattr(data_config, "categorical_features"):
-        for col in data_config.categorical_features:
-            if col in data.columns:
-                data[col] = data[col].astype("category")
+        data = _cast_categoricals(data, data_config.categorical_features)
 
     return data
+
+
+def _cast_categoricals(
+    data: pd.DataFrame, columns: list[str]
+) -> pd.DataFrame:
+    """Return a copy of *data* with the given columns cast to categorical dtype.
+
+    Columns not present in *data* are silently skipped.
+    """
+    return data.assign(
+        **{col: data[col].astype("category") for col in columns if col in data.columns}
+    )

--- a/numerical_illustration/tasks/load_input_data.py
+++ b/numerical_illustration/tasks/load_input_data.py
@@ -71,4 +71,11 @@ def _load_data_from_file(data_config: DataConfig) -> pd.DataFrame:
     if "w" not in data.columns:
         data["w"] = 1
 
+    # Cast configured columns to pd.CategoricalDtype so that
+    # CyclicalGradientBooster can detect them automatically.
+    if hasattr(data_config, "categorical_features"):
+        for col in data_config.categorical_features:
+            if col in data.columns:
+                data[col] = data[col].astype("category")
+
     return data

--- a/numerical_illustration/tasks/preprocess_input_data.py
+++ b/numerical_illustration/tasks/preprocess_input_data.py
@@ -35,17 +35,25 @@ def _normalize_features(
     test_data: pd.DataFrame,
     features: list[str],
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Normalize features using training-set statistics only.
+    """Normalize numeric features using training-set statistics only.
+
+    Categorical features (``pd.CategoricalDtype``) are skipped.
 
     Args:
         train_data: training data
         test_data: test data
-        features: list of feature column names to normalize
+        features: list of feature column names to consider
     """
-    mean = train_data[features].mean()
-    std = train_data[features].std()
-    train_data[features] = (train_data[features] - mean) / std
-    test_data[features] = (test_data[features] - mean) / std
+    numeric_features = [
+        f for f in features
+        if not isinstance(train_data[f].dtype, pd.CategoricalDtype)
+    ]
+    if not numeric_features:
+        return train_data, test_data
+    mean = train_data[numeric_features].mean()
+    std = train_data[numeric_features].std()
+    train_data[numeric_features] = (train_data[numeric_features] - mean) / std
+    test_data[numeric_features] = (test_data[numeric_features] - mean) / std
     return train_data, test_data
 
 

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -110,7 +110,7 @@ def tune_models(
 
 
 def _tune_ngboost(
-    X: np.ndarray,
+    X: "np.ndarray | pd.DataFrame",
     y: np.ndarray,
     w: np.ndarray,
     distribution: Distribution,
@@ -123,6 +123,23 @@ def _tune_ngboost(
 ) -> dict[str, Any]:
     """Tune NGBoost n_estimators via k-fold CV using staged_pred_dist,
     mirroring the same fold split and loss computation as CGBM tuning."""
+    import pandas as pd
+    from sklearn.preprocessing import OneHotEncoder
+
+    # NGBoost requires numeric input; one-hot encode categoricals.
+    if isinstance(X, pd.DataFrame):
+        cat_cols = [
+            c for c in X.columns
+            if isinstance(X[c].dtype, pd.CategoricalDtype)
+        ]
+        if cat_cols:
+            num_cols = [c for c in X.columns if c not in cat_cols]
+            enc = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
+            encoded = enc.fit_transform(X[cat_cols])
+            numeric = X[num_cols].to_numpy(dtype=float, na_value=0.0)
+            X = np.hstack([numeric, encoded])
+        else:
+            X = X.to_numpy(dtype=float, na_value=0.0)
     folds = _fold_split(X=X, y=y, w=w, n_splits=n_folds, rng=rng)
 
     fold_train_losses = []

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -7,6 +7,7 @@ from ngboost import NGBRegressor
 from ngboost.distns import Normal
 from ngboost.scores import MLE
 from sklearn.tree import DecisionTreeRegressor
+from sklearn.preprocessing import OneHotEncoder
 
 from cyc_gbm import CyclicalGradientBooster
 from cyc_gbm.utils.distributions import Distribution
@@ -123,7 +124,6 @@ def _tune_ngboost(
 ) -> dict[str, Any]:
     """Tune NGBoost n_estimators via k-fold CV using staged_pred_dist,
     mirroring the same fold split and loss computation as CGBM tuning."""
-    from sklearn.preprocessing import OneHotEncoder
 
     # NGBoost requires numeric input; one-hot encode categoricals.
     if isinstance(X, pd.DataFrame):

--- a/numerical_illustration/tasks/tune_models.py
+++ b/numerical_illustration/tasks/tune_models.py
@@ -110,7 +110,7 @@ def tune_models(
 
 
 def _tune_ngboost(
-    X: "np.ndarray | pd.DataFrame",
+    X: np.ndarray | pd.DataFrame,
     y: np.ndarray,
     w: np.ndarray,
     distribution: Distribution,
@@ -123,7 +123,6 @@ def _tune_ngboost(
 ) -> dict[str, Any]:
     """Tune NGBoost n_estimators via k-fold CV using staged_pred_dist,
     mirroring the same fold split and loss computation as CGBM tuning."""
-    import pandas as pd
     from sklearn.preprocessing import OneHotEncoder
 
     # NGBoost requires numeric input; one-hot encode categoricals.

--- a/numerical_illustration/tasks/utils/utils.py
+++ b/numerical_illustration/tasks/utils/utils.py
@@ -9,6 +9,8 @@ def get_targets_features(
 
     Returns ``X`` as a :class:`~pandas.DataFrame` so that
     ``pd.CategoricalDtype`` columns are preserved for tree-based models.
+    ``y`` and ``w`` are returned as numpy arrays for compatibility with
+    the distribution and model APIs.
 
     Args:
         data: pipeline DataFrame containing feature columns, ``y``, ``w``,
@@ -24,6 +26,6 @@ def get_targets_features(
         if col not in ["y", "w"] and not col.startswith("theta")
     ]
     X = data[features]
-    y = data["y"].values
-    w = data["w"].values
+    y = data["y"].to_numpy()
+    w = data["w"].to_numpy()
     return X, y, w

--- a/numerical_illustration/tasks/utils/utils.py
+++ b/numerical_illustration/tasks/utils/utils.py
@@ -2,13 +2,28 @@ import numpy as np
 import pandas as pd
 
 
-def get_targets_features(train_data: pd.DataFrame) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def get_targets_features(
+    data: pd.DataFrame,
+) -> tuple[pd.DataFrame, np.ndarray, np.ndarray]:
+    """Extract features, target and weights from a pipeline DataFrame.
+
+    Returns ``X`` as a :class:`~pandas.DataFrame` so that
+    ``pd.CategoricalDtype`` columns are preserved for tree-based models.
+
+    Args:
+        data: pipeline DataFrame containing feature columns, ``y``, ``w``,
+            and optionally ``theta_*`` columns.
+
+    Returns:
+        Tuple of ``(X, y, w)`` where ``X`` is a DataFrame and ``y``, ``w``
+        are numpy arrays.
+    """
     features = [
         col
-        for col in train_data.columns
+        for col in data.columns
         if col not in ["y", "w"] and not col.startswith("theta")
     ]
-    X_train = train_data[features].values
-    y_train = train_data["y"].values
-    w_train = train_data["w"].values
-    return X_train, y_train, w_train
+    X = data[features]
+    y = data["y"].values
+    w = data["w"].values
+    return X, y, w


### PR DESCRIPTION
## Summary
- `get_targets_features` now returns `X` as a DataFrame (preserving `pd.CategoricalDtype`) instead of a numpy array
- Add `categorical_features` list to `LocalDataConfig`; `load_input_data` casts those columns to category dtype on load
- `_fold_split` handles DataFrame `X` via `iloc` indexing
- `_normalize_features` skips categorical columns
- CGLM and NGBoost baseline models one-hot encode categorical columns internally (they require numeric input)
- NGBoost tuning path one-hot encodes categoricals before fold split

This enables the tree-based models (GBM, CGBM) to use sklearn's native categorical feature splits while baseline models fall back to one-hot encoding.

**Stack:** 3/4 → `feature/min-samples-leaf-config`