### PR TITLE
[Feature] Add shape-rate gamma numerical illustration config

### DIFF
--- a/numerical_illustration/configs/gamma_shape_rate.yaml
+++ b/numerical_illustration/configs/gamma_shape_rate.yaml
@@ -1,0 +1,51 @@
+data:
+  data_source: simulation
+  distribution: gamma
+  parameterization: shape-rate
+  random_seed: 11
+  n_samples: 100000
+  n_features: 6
+  test_size: 0.2
+  normalize_features: true
+  parameter_function: |
+    def parameter(X):
+        # log(alpha) = a1*x1 + a2*x2^2 + a3*|x3|*sin(a4*x3) + a5*x4*x5 + a6*x5^2*x6
+        # a1=0.4, a2=0.2, a3=0.3, a4=1.5, a5=0.15, a6=0.1
+        z0 = (0.4 * X[:,0]
+              + 0.2 * X[:,1]**2
+              + 0.3 * np.abs(X[:,2]) * np.sin(1.5 * X[:,2])
+              + 0.15 * X[:,3] * X[:,4]
+              + 0.1 * X[:,4]**2 * X[:,5])
+        # log(beta) = b0 + b1*x2 + b2*|x1|
+        # b0=-1.0, b1=0.5, b2=0.4
+        z1 = (-1.0
+              + 0.5 * X[:,1]
+              + 0.4 * np.abs(X[:,0]))
+        return np.stack([z0, z1])
+
+output:
+  output_dir: data/results
+
+models:
+  - model_class: intercept
+  - model_class: cglm
+    max_iter: 2000
+    tolerance: 1e-5
+    step_size: 0.1
+  - model_class: gbm
+    n_estimators: 600
+    max_depth: 4
+    learning_rate: 0.05
+  - model_class: cgbm
+    n_estimators: [500, 500]
+    max_depth: 4
+    learning_rate: [0.05, 0.01]
+
+bootstrap:
+  n_bootstraps: 1
+  parallel: true
+  n_jobs: -1
+
+tuning:
+  perform_tuning: true
+  n_folds: 4

--- a/numerical_illustration/schema/data.py
+++ b/numerical_illustration/schema/data.py
@@ -21,13 +21,14 @@ class DataConfig(BaseModel):
     """
 
     distribution: str
+    parameterization: str = "mean-dispersion"
     test_size: float = 0.2
     normalize_features: bool = True
 
     @property
     def distribution_object(self) -> Distribution:
         """Instantiate and return the ``Distribution`` object."""
-        return initiate_distribution(self.distribution)
+        return initiate_distribution(self.distribution, parameterization=self.parameterization)
 
 
 class SimulationConfig(DataConfig):

--- a/tests/test_cyc_gbm.py
+++ b/tests/test_cyc_gbm.py
@@ -1,12 +1,11 @@
 import unittest
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from cyc_gbm import CyclicalGradientBooster
 from cyc_gbm.utils.tuning import tune_n_estimators
-from cyc_gbm.utils.distributions import GammaShapeRateDistribution, initiate_distribution
+from cyc_gbm.utils.distributions import initiate_distribution
 
 
 class CyclicalGradientBoosterTestCase(unittest.TestCase):
@@ -275,35 +274,6 @@ class CyclicalGradientBoosterTestCase(unittest.TestCase):
                     msg=f"Feature importance for feature {feature} for parameter j = {j} not as expected",
                 )
 
-
-class DataConfigParameterizationTestCase(unittest.TestCase):
-    """Tests that DataConfig correctly passes parameterization to the distribution factory."""
-
-    def test_default_parameterization_is_mean_dispersion(self):
-        """DataConfig defaults to mean-dispersion and produces a non-shape-rate distribution."""
-        from numerical_illustration.schema.data import SimulationConfig
-        cfg = SimulationConfig(
-            data_source="simulation",
-            distribution="gamma",
-            n_samples=10,
-            n_features=2,
-            parameter_function="def parameter(X): import numpy as np; return np.zeros((2, len(X)))",
-        )
-        self.assertEqual(cfg.parameterization, "mean-dispersion")
-        self.assertNotIsInstance(cfg.distribution_object, GammaShapeRateDistribution)
-
-    def test_shape_rate_parameterization_produces_correct_distribution(self):
-        """DataConfig with parameterization='shape-rate' produces GammaShapeRateDistribution."""
-        from numerical_illustration.schema.data import SimulationConfig
-        cfg = SimulationConfig(
-            data_source="simulation",
-            distribution="gamma",
-            parameterization="shape-rate",
-            n_samples=10,
-            n_features=2,
-            parameter_function="def parameter(X): import numpy as np; return np.zeros((2, len(X)))",
-        )
-        self.assertIsInstance(cfg.distribution_object, GammaShapeRateDistribution)
 
 
 if __name__ == "__main__":

--- a/tests/test_cyc_gbm.py
+++ b/tests/test_cyc_gbm.py
@@ -1,11 +1,12 @@
 import unittest
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from cyc_gbm import CyclicalGradientBooster
 from cyc_gbm.utils.tuning import tune_n_estimators
-from cyc_gbm.utils.distributions import initiate_distribution
+from cyc_gbm.utils.distributions import GammaShapeRateDistribution, initiate_distribution
 
 
 class CyclicalGradientBoosterTestCase(unittest.TestCase):
@@ -273,6 +274,36 @@ class CyclicalGradientBoosterTestCase(unittest.TestCase):
                     places=5,
                     msg=f"Feature importance for feature {feature} for parameter j = {j} not as expected",
                 )
+
+
+class DataConfigParameterizationTestCase(unittest.TestCase):
+    """Tests that DataConfig correctly passes parameterization to the distribution factory."""
+
+    def test_default_parameterization_is_mean_dispersion(self):
+        """DataConfig defaults to mean-dispersion and produces a non-shape-rate distribution."""
+        from numerical_illustration.schema.data import SimulationConfig
+        cfg = SimulationConfig(
+            data_source="simulation",
+            distribution="gamma",
+            n_samples=10,
+            n_features=2,
+            parameter_function="def parameter(X): import numpy as np; return np.zeros((2, len(X)))",
+        )
+        self.assertEqual(cfg.parameterization, "mean-dispersion")
+        self.assertNotIsInstance(cfg.distribution_object, GammaShapeRateDistribution)
+
+    def test_shape_rate_parameterization_produces_correct_distribution(self):
+        """DataConfig with parameterization='shape-rate' produces GammaShapeRateDistribution."""
+        from numerical_illustration.schema.data import SimulationConfig
+        cfg = SimulationConfig(
+            data_source="simulation",
+            distribution="gamma",
+            parameterization="shape-rate",
+            n_samples=10,
+            n_features=2,
+            parameter_function="def parameter(X): import numpy as np; return np.zeros((2, len(X)))",
+        )
+        self.assertIsInstance(cfg.distribution_object, GammaShapeRateDistribution)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds an optional `parameterization` field (default `\"mean-dispersion\"`) to `DataConfig` in the numerical illustration schema, wired through to `initiate_distribution` so configs can elect to use `GammaShapeRateDistribution`.
- Adds `numerical_illustration/configs/gamma_shape_rate.yaml` — uses the same DGP functional form as `gamma.yaml` but interprets `z0` as `log(alpha)` (log-shape) and `z1` as `log(beta)` (log-rate).
- Adds two unit tests in `DataConfigParameterizationTestCase` verifying the default remains `mean-dispersion` and that `shape-rate` resolves to `GammaShapeRateDistribution`.

## Validation

All 17 tests pass (`uv run --extra numerical-illustration python -m pytest tests/ -v`). The `test_feature_importance` test is flaky when the full suite is run due to shared RNG state across test methods — pre-existing on `main` and unrelated to this change.